### PR TITLE
fix(frontend): keep site export format menus clickable

### DIFF
--- a/frontend/dashboard/e2e/export.seeded.spec.js
+++ b/frontend/dashboard/e2e/export.seeded.spec.js
@@ -1,0 +1,89 @@
+const { test, expect } = require("playwright/test");
+const { login } = require("./support/auth");
+
+test("export format menus download all-sites and per-site takeouts", async ({ page }) => {
+    await page.setViewportSize({ width: 1110, height: 866 });
+    await login(page, "/import-export/export");
+    const originalLocale = await currentLocale(page);
+    await setLocale(page, "de");
+    const extraSite = await createSite(page);
+
+    try {
+        await page.goto("/import-export/export", { waitUntil: "domcontentloaded" });
+
+        await expect(page.getByRole("heading", { name: "Import & Export" })).toBeVisible();
+        await expect(page.locator("html")).toHaveAttribute("lang", /de/i);
+        await expect(page.getByRole("heading", { name: /^Alle zugänglichen Sites$/ })).toBeVisible();
+        await expect(page.getByRole("heading", { name: /^Site-Exporte$/ })).toBeVisible();
+
+        const allSitesMenu = page.locator('[data-testid="all-sites-export-primary"] .p-splitbutton-dropdown').first();
+        await expect(allSitesMenu).toBeVisible();
+        await allSitesMenu.click();
+
+        const allSitesDownload = page.waitForEvent("download");
+        const allSitesResponse = page.waitForResponse((response) => response.url().includes("/api/user/takeout?format=json") && response.ok());
+        await clickMenuItem(page, "JSON");
+        const [allSitesDownloadEvent] = await Promise.all([allSitesDownload, allSitesResponse]);
+        expect(allSitesDownloadEvent.suggestedFilename().toLowerCase()).toContain(".json");
+
+        const siteRow = page.locator(".site-export-row").filter({ hasText: extraSite.domain }).first();
+        await expect(siteRow).toBeVisible();
+
+        const siteExportMenu = siteRow.locator(".p-splitbutton-dropdown").first();
+        await expect(siteExportMenu).toBeVisible();
+        await siteExportMenu.click();
+
+        const siteDownload = page.waitForEvent("download");
+        const siteResponse = page.waitForResponse((response) => response.url().includes(`/api/sites/${extraSite.id}/takeout?format=json`) && response.ok());
+        await clickMenuItem(page, "JSON");
+        const [siteDownloadEvent] = await Promise.all([siteDownload, siteResponse]);
+        expect(siteDownloadEvent.suggestedFilename().toLowerCase()).toContain(".json");
+    } finally {
+        await deleteSite(page, extraSite.id);
+        await setLocale(page, originalLocale);
+    }
+});
+
+async function clickMenuItem(page, name) {
+    const item = page.getByRole("menuitem", { name, exact: true });
+    await expect(item).toBeVisible();
+    await item.click();
+}
+
+async function setLocale(page, locale) {
+    const response = await page.request.put("/api/user/preferences", {
+        headers: originHeaders(page),
+        data: { default_locale: locale }
+    });
+    const body = await response.text();
+    expect(response.ok(), `set locale returned ${response.status()}: ${body}`).toBeTruthy();
+}
+
+async function currentLocale(page) {
+    const response = await page.request.get("/api/user/preferences");
+    const body = await response.text();
+    expect(response.ok(), `get locale returned ${response.status()}: ${body}`).toBeTruthy();
+    return JSON.parse(body).default_locale || "en";
+}
+
+async function createSite(page) {
+    const domain = `site-export-e2e-${Date.now()}.example.test`;
+    const response = await page.request.post("/api/sites", {
+        headers: originHeaders(page),
+        data: { domain }
+    });
+    const body = await response.text();
+    expect(response.ok(), `create site returned ${response.status()}: ${body}`).toBeTruthy();
+    return JSON.parse(body);
+}
+
+async function deleteSite(page, siteId) {
+    const response = await page.request.delete(`/api/sites/${siteId}`, {
+        headers: originHeaders(page)
+    });
+    expect([200, 404]).toContain(response.status());
+}
+
+function originHeaders(page) {
+    return { Origin: new URL(page.url()).origin };
+}

--- a/frontend/dashboard/src/app/pages/import-export/import-export-export.spec.ts
+++ b/frontend/dashboard/src/app/pages/import-export/import-export-export.spec.ts
@@ -213,6 +213,30 @@ describe('ImportExportExportPage', () => {
         expect(siteExportRow('site-1').textContent).not.toContain('Site export downloaded.');
     });
 
+    it('keeps repeated alternate-format menu reads bound to the intended site row', () => {
+        setSites([site('site-1', 'alpha.example.com'), site('site-2', 'beta.example.com')]);
+
+        const component = fixture.componentInstance as unknown as ExportPageTestAccess;
+        const firstMenu = component.siteExportMenuItems('site-1');
+        const secondMenu = component.siteExportMenuItems('site-1');
+
+        expect(secondMenu.map((item) => item.label)).toEqual(firstMenu.map((item) => item.label));
+
+        const item = secondMenu.find((entry) => entry.label === 'JSON');
+        expect(item).toBeTruthy();
+        (item!.command as (() => void) | undefined)?.();
+        fixture.detectChanges();
+
+        const req = httpMock.expectOne('/api/sites/site-1/takeout?format=json');
+        expect(req.request.method).toBe('GET');
+        httpMock.expectNone('/api/sites/site-2/takeout?format=json');
+        req.flush(new Blob(['json'], { type: 'application/json' }), {
+            headers: new HttpHeaders({
+                'content-disposition': 'attachment; filename="alpha.json"'
+            })
+        });
+    });
+
     it('keeps per-site error state isolated to the selected row', () => {
         setSites([site('site-1', 'alpha.example.com'), site('site-2', 'beta.example.com')]);
 

--- a/frontend/dashboard/src/app/pages/import-export/import-export-export.ts
+++ b/frontend/dashboard/src/app/pages/import-export/import-export-export.ts
@@ -32,6 +32,7 @@ export class ImportExportExportPage {
     private readonly siteService = inject(SiteService);
     private readonly transloco = inject(TranslocoService);
     private readonly activeLanguage = toSignal(this.transloco.langChanges$, { initialValue: this.transloco.getActiveLang() });
+    private readonly siteExportMenuItemsCache = new Map<string, { language: string; items: MenuItem[] }>();
     protected readonly sites = this.siteService.sites;
     protected readonly isSitesLoading = this.siteService.isLoading;
     protected readonly allSitesExportMenuItems = computed<MenuItem[]>(() => {
@@ -60,13 +61,20 @@ export class ImportExportExportPage {
     }
 
     protected siteExportMenuItems(siteID: string): MenuItem[] {
-        this.activeLanguage();
-        return buildTakeoutExportMenuItems(this.transloco, (format) => {
+        const language = this.activeLanguage();
+        const cached = this.siteExportMenuItemsCache.get(siteID);
+        if (cached?.language === language) {
+            return cached.items;
+        }
+
+        const items = buildTakeoutExportMenuItems(this.transloco, (format) => {
             const site = this.sites().find((entry) => entry.id === siteID);
             if (site) {
                 this.downloadSite(site, format);
             }
         });
+        this.siteExportMenuItemsCache.set(siteID, { language, items });
+        return items;
     }
 
     protected isSiteExporting(siteID: string): boolean {


### PR DESCRIPTION
## Summary
- Fixes site export alternate-format SplitButton actions by keeping per-site menu models stable per site and active language.
- Adds a focused unit regression for repeated per-site menu reads staying bound to the intended site.
- Adds seeded Playwright coverage for German all-sites and per-site JSON export downloads at the reported desktop viewport.

## Release
- Target release: 2.4.2
- Fixes #151

## Verification
- `cd frontend/dashboard && npm run test -- --watch=false --no-progress --include src/app/pages/import-export/import-export-export.spec.ts`
- `cd frontend/dashboard && npm run test:e2e -- e2e/export.seeded.spec.js`
- `cd frontend/dashboard && npm run fmt:check`
- `cd frontend/dashboard && npm run lint`

## Notes
- Left local `frontend/dashboard/package-lock.json` whitespace-only churn unstaged; it is unrelated to this fix.
