### PR TITLE
fix(frontend): resolve settings password validation, breadcrumbs scrollbar, GSC timezone tests and i18n pt_BR translation upgrades

### DIFF
--- a/frontend/dashboard/public/i18n/pt.json
+++ b/frontend/dashboard/public/i18n/pt.json
@@ -26,7 +26,7 @@
         "funnels": "Funis",
         "utm": "UTM",
         "apiClients": "Clientes de API",
-        "apiReference": "Referência de API",
+        "apiReference": "API Doc.",
         "expandItem": "Expandir {{item}}",
         "collapseItem": "Recolher {{item}}",
         "imports": "Importações",
@@ -41,11 +41,11 @@
         "supportAria": "Abrir suporte do HitKeep em uma nova guia",
         "settings": "Configurações",
         "settingsAria": "Ir para configurações",
-        "emailReports": "Relatórios por E-mail",
-        "emailReportsAria": "Ir para relatórios por e-mail",
+        "emailReports": "Relatórios",
+        "emailReportsAria": "Ir para relatórios",
         "administration": "Administração",
-        "systemSettings": "Configurações do Sistema",
-        "systemSettingsAria": "Ir para configurações do sistema",
+        "systemSettings": "Configurações",
+        "systemSettingsAria": "Ir para configurações",
         "teamOverview": "Visão Geral da Equipe",
         "teamOverviewAria": "Ir para visão geral da equipe",
         "teamMembers": "Membros da Equipe",
@@ -62,7 +62,8 @@
         "googleSearchConsole": "Search Console",
         "googleSearchConsoleAria": "Ir para integração com o Google Search Console",
         "webVitals": "Web Vitals",
-        "webVitalsAria": "Abrir análises do Web Vitals"
+        "webVitalsAria": "Abrir análises do Web Vitals",
+        "qrCodes": "Códigos QR"
     },
     "auditTable": {
         "empty": "Nenhum registro de auditoria encontrado",
@@ -938,7 +939,7 @@
         },
         "reports": {
             "breadcrumb": "Relatórios por E-mail",
-            "subtitle": "Configure e-mails de análises agendados para seus sites.",
+            "subtitle": "Configure o agendamento de envio de e-mails de análises dos seus sites.",
             "digest": {
                 "title": "Resumo Consolidado",
                 "description": "Receba um e-mail de resumo para todos os seus sites."
@@ -2811,6 +2812,127 @@
         "empty": {
             "title": "Sem Web Vitals ainda",
             "description": "Ative o Web Vitals no código de rastreamento para começar a coletar amostras de desempenho dos usuários."
+        }
+    },
+    "qrCodes": {
+        "breadcrumb": "Códigos QR",
+        "actions": {
+            "create": "Criar código QR",
+            "exportSvg": "Exportar SVG",
+            "exportPng": "Exportar PNG",
+            "removeAsset": "Remover imagem",
+            "viewAnalytics": "Ver estatísticas",
+            "backToList": "Voltar para campanhas QR",
+            "takeout": "Exportar dados",
+            "addParam": "Adicionar parâmetro",
+            "chooseAsset": "Escolher imagem",
+            "exportArtwork": "Exportar arte",
+            "exportPngSize": "PNG {{size}} px"
+        },
+        "list": {
+            "title": "Campanhas QR",
+            "count": "{{count}} códigos salvos"
+        },
+        "empty": {
+            "title": "Nenhuma campanha QR ainda",
+            "description": "Crie um código QR dinâmico com atribuição de campanha, exportações prontas para impressão e estatísticas dedicadas."
+        },
+        "fields": {
+            "name": "Nome",
+            "destinationUrl": "URL de destino",
+            "redirectUrl": "URL de redirecionamento",
+            "finalUrl": "URL final rastreada",
+            "customParams": "Parâmetros personalizados",
+            "asset": "Imagem gráfica",
+            "paramKey": "Parâmetro",
+            "paramValue": "Valor"
+        },
+        "asset": {
+            "present": "Imagem gráfica",
+            "none": "Nenhuma"
+        },
+        "kpis": {
+            "opens": "Aberturas"
+        },
+        "analytics": {
+            "fullAnalytics": "Estatísticas completas",
+            "opensTitle": "Aberturas de QR",
+            "opensDescription": "Redirecionamento de aberturas para este código antes que o visitante chegue ao destino rastreado.",
+            "emptyTitle": "Nenhuma abertura de QR ainda",
+            "emptyDescription": "As leituras aparecerão aqui após este código QR ser utilizado."
+        },
+        "share": {
+            "title": "Compartilhar estatísticas de QR",
+            "description": "Crie um link somente leitura que exponha apenas este código QR e suas exportações.",
+            "create": "Criar link de compartilhamento de QR",
+            "dialogTitle": "Links de compartilhamento de QR",
+            "created": "Link de compartilhamento criado",
+            "createSuccess": "Link de compartilhamento de QR criado.",
+            "deleteSuccess": "Link de compartilhamento de QR excluído.",
+            "deleteConfirmTitle": "Excluir link de compartilhamento de QR",
+            "deleteConfirmMessage": "Excluir este link de compartilhamento apenas de QR? Visitantes existentes perderão o acesso à página de estatísticas compartilhadas.",
+            "tokenHint": "Dica do token",
+            "url": "URL de compartilhamento",
+            "urlUnavailable": "A URL só é exibida quando o link é gerado pela primeira vez.",
+            "empty": "Nenhum link de compartilhamento apenas de QR ainda.",
+            "invalid": "Este link de compartilhamento de QR é inválido ou expirou.",
+            "readOnlyBadge": "Estatísticas de QR somente leitura",
+            "sharedStats": "Estatísticas compartilhadas"
+        },
+        "editor": {
+            "createTitle": "Criar campanha QR",
+            "editTitle": "Editar campanha QR",
+            "subtitle": "Códigos QR salvos usam uma URL dinâmica de redirecionamento do HitKeep para que os campos da campanha possam ser alterados após a impressão.",
+            "destination": "Destino e campanha",
+            "style": "Estilo e imagem gráfica",
+            "saveError": "Não foi possível salvar o código QR. Verifique os campos e tente novamente.",
+            "assetError": "Não foi possível enviar a imagem do QR.",
+            "assetDeleteError": "Não foi possível remover a imagem do QR.",
+            "redirectAfterSave": "Disponível após salvar",
+            "customParamsHint": "Adicione parâmetros de consulta opcionais que acompanham esta campanha impressa.",
+            "assetHint": "PNG, JPEG ou WebP. Máximo de 2 MB."
+        },
+        "style": {
+            "foreground": "Primeiro plano",
+            "background": "Plano de fundo",
+            "dotsLabel": "Estilo dos pontos",
+            "cornersLabel": "Estilo dos cantos",
+            "dots": {
+                "square": "Quadrado",
+                "dots": "Pontos",
+                "rounded": "Arredondado",
+                "extra-rounded": "Super arredondado",
+                "classy": "Elegante",
+                "classy-rounded": "Elegante arredondado"
+            },
+            "corners": {
+                "square": "Quadrado",
+                "dot": "Ponto",
+                "extra-rounded": "Super arredondado"
+            }
+        },
+        "warnings": {
+            "invalidDestination": "Insira um destino HTTPS ou HTTP válido antes de exportar.",
+            "missingCampaign": "Adicione uma origem UTM ou campanha para facilitar a reconciliação do recurso impresso mais tarde.",
+            "longUrl": "A URL final é longa o suficiente para tornar códigos QR densos mais difíceis de escanear.",
+            "reservedParam": "hk_qr é reservado para atribuição do HitKeep e será sobrescrito pelo redirecionamento."
+        },
+        "errors": {
+            "load": "Não foi possível carregar as campanhas QR.",
+            "retry": "Atualize a página ou tente novamente em um momento.",
+            "archive": "Não foi possível arquivar o código QR.",
+            "notFound": "Campanha QR não encontrada.",
+            "stats": "Não foi possível carregar as estatísticas de QR.",
+            "share": "Não foi possível atualizar os links de compartilhamento de QR.",
+            "takeout": "Não foi possível exportar os dados de QR."
+        },
+        "status": {
+            "archiveSuccess": "Campanha QR arquivada.",
+            "takeoutSuccess": "Exportação de dados de QR iniciada."
+        },
+        "confirm": {
+            "archiveTitle": "Arquivar campanha QR",
+            "archiveMessage": "Arquivar {{name}}? Códigos impressos ainda redirecionarão, mas os profissionais de marketing não verão mais esta campanha na lista ativa."
         }
     },
     "cloud": {

--- a/frontend/dashboard/src/app/core/components/page-breadcrumb/page-breadcrumb.css
+++ b/frontend/dashboard/src/app/core/components/page-breadcrumb/page-breadcrumb.css
@@ -21,3 +21,12 @@
 :host ::ng-deep .p-breadcrumb .p-breadcrumb-chevron {
     line-height: 1;
 }
+
+:host ::ng-deep .p-breadcrumb {
+    scrollbar-width: none; /* Firefox */
+    -ms-overflow-style: none; /* IE/Edge */
+}
+
+:host ::ng-deep .p-breadcrumb::-webkit-scrollbar {
+    display: none; /* Chrome/Safari/Opera */
+}

--- a/frontend/dashboard/src/app/features/analytics/components/search-console-drilldown.ts
+++ b/frontend/dashboard/src/app/features/analytics/components/search-console-drilldown.ts
@@ -560,12 +560,14 @@ export class SearchConsoleDrilldown {
         const start = new Intl.DateTimeFormat(language, {
             month: 'short',
             day: 'numeric',
+            timeZone: 'UTC',
             ...(sameYear ? {} : { year: 'numeric' })
         }).format(from);
         const end = new Intl.DateTimeFormat(language, {
             month: 'short',
             day: 'numeric',
-            year: 'numeric'
+            year: 'numeric',
+            timeZone: 'UTC'
         }).format(to);
         return `${start} - ${end}`;
     }

--- a/frontend/dashboard/src/app/features/settings/components/settings-security.spec.ts
+++ b/frontend/dashboard/src/app/features/settings/components/settings-security.spec.ts
@@ -17,7 +17,8 @@ describe('SettingsSecurity', () => {
     let clickSpy: ReturnType<typeof vi.fn>;
 
     const authServiceMock = {
-        changePassword: vi.fn(() => of(void 0))
+        // eslint-disable-next-line @typescript-eslint/no-unused-vars
+        changePassword: vi.fn((current: string, newPass: string) => of(void 0))
     };
 
     const userSecurityServiceMock = {
@@ -146,5 +147,20 @@ describe('SettingsSecurity', () => {
         expect(clickSpy).toHaveBeenCalledTimes(1);
         expect(revokeObjectURLSpy).toHaveBeenCalledWith('blob:recovery-codes');
         expect(component['recoveryCodeSuccess']()).toBe('settings.security.recoveryCodes.downloaded');
+    });
+
+    it('does not submit if password form is invalid', () => {
+        component['form'].currentPassword().control().setValue('');
+        component['form'].newPassword().control().setValue('');
+        component['onSubmit']();
+        expect(authServiceMock.changePassword).not.toHaveBeenCalled();
+    });
+
+    it('submits if password form is valid even if TOTP form is invalid', () => {
+        component['form'].currentPassword().control().setValue('old-password');
+        component['form'].newPassword().control().setValue('new-password-123');
+        // TOTP code is empty and thus invalid, but we only care about password form
+        component['onSubmit']();
+        expect(authServiceMock.changePassword).toHaveBeenCalledWith('old-password', 'new-password-123');
     });
 });

--- a/frontend/dashboard/src/app/features/settings/components/settings-security.ts
+++ b/frontend/dashboard/src/app/features/settings/components/settings-security.ts
@@ -68,7 +68,7 @@ export class SettingsSecurity {
 
     protected onSubmit(event?: Event): void {
         event?.preventDefault();
-        if (this.form().invalid()) {
+        if (this.form.currentPassword().invalid() || this.form.newPassword().invalid()) {
             this.form.currentPassword().markAsTouched();
             this.form.newPassword().markAsTouched();
             return;


### PR DESCRIPTION
## Description
    
This pull request resolves three frontend issues:
    
1. **Password Settings Form Validation Bug**:
    - **Problem**: When attempting to update a password on the `/settings` security tab, the submission handler (`onSubmit`) validated the entire form group via `this.form().invalid()`. Since the same model includes other unrelated forms/fields (like TOTP and passkey configurations) which require input and are empty by default, the form was marked invalid, silently preventing password updates.
    - **Solution**: Updated `onSubmit` to explicitly check only the password controls (`currentPassword` and `newPassword`) rather than the entire form group. Added unit tests inside `settings-security.spec.ts` to verify this behavior.

2. **Google Search Console Date Range Timezone Bug**:
    - **Problem**: The unit test `shows the dashboard date range and Search Console-supported filters` was failing on local environments using non-UTC timezones because dates were being formatted in the local timezone, causing date shifts (e.g. from May 1 to Apr 30).
    - **Solution**: Forced the `timeZone: 'UTC'` parameter in the `Intl.DateTimeFormat` configuration within `dateRangeLabel()` inside `search-console-drilldown.ts`.

3. **Breadcrumbs Scrollbar Overflow Glitch**:
    - **Problem**: Long translated breadcrumb labels (like "Configurações" instead of "Settings" in Portuguese) were occasionally causing ugly scrollbars to appear on desktop layouts.
    - **Solution**: Added CSS rules inside `page-breadcrumb.css` to hide scrollbars on `.p-breadcrumb` wrapper while maintaining mobile swiping behavior.

4. **Portuguese (pt_BR) Translation Enhancements**:
    - **Problem**: Some Portuguese translation strings were too long for sidebar navigation and breadcrumbs, causing layout stress (e.g. "Configurações do Sistema" and "Relatórios por E-mail"). Additionally, the newly introduced dynamic QR codes module was missing translations for its labels, breadcrumbs, buttons, and validation warnings.
    - **Solution**: 
      - Shortened "Configurações do Sistema" to "Configurações" and "Relatórios por E-mail" to "Relatórios".
      - Shortened the API Reference navigation link from "Referência de API" to "API Doc.".
      - Improved the subtitle for email reports to: "Configure o agendamento de envio de e-mails de análises dos seus sites.".
     - Added full translation coverage for the new `qrCodes` scope in `pt.json` synced with the English keys, resolving missing label warnings on the UTM campaign QR code view.

## Contributor Checklist

- [x] I updated docs or explained why docs are not needed. *(No documentation is required as these are layout and behavior bug fixes.)*
- [x] I checked the diff for secrets, private deployment details, local-only paths, and customer data.

## Verification Run

Here are the verification tests run on the workspace branch:

- `npm run lint` -> Passed
- `npm run fmt:check` -> Passed
- `npx ng test --include src/app/features/settings/components/settings-security.spec.ts --watch=false --no-progress` -> Passed (6 tests)
- `npx ng test --include src/app/features/analytics/components/search-console-drilldown.spec.ts --watch=false --no-progress` -> Passed (8 tests)
- npm run i18n:check  -> Passed (all keys are perfectly matched with the official English file). 
- npm run fmt:check  -> Passed.
