### PR TITLE
feat(billing): add annual conversion flow

### DIFF
--- a/frontend/dashboard/public/i18n/de.json
+++ b/frontend/dashboard/public/i18n/de.json
@@ -1754,6 +1754,11 @@
           "currentPlan": "Aktueller Tarif",
           "recommended": "Empfohlen",
           "perMonth": "/Monat",
+          "perYear": "/Jahr",
+          "billingLabel": "Abrechnungsintervall",
+          "monthly": "Monatlich",
+          "annual": "Jährlich",
+          "annualSaving": "2 Monate kostenlos",
           "openSource": {
             "note": "HitKeep ist vollständig Open Source – einschließlich aller Bezahlfunktionen. Cloud-Tarife finanzieren Hosting und Weiterentwicklung.",
             "support": "Möchtest du uns anders unterstützen?",
@@ -2536,6 +2541,20 @@
   "signup": {
     "title": "Starte kostenloses Tracking für deine Websites",
     "subtitle": "Erstelle deinen Workspace und tracke in unter einer Minute. Keine Kreditkarte erforderlich.",
+    "paidIntentNote": "Nach der E-Mail-Bestätigung öffnen wir den sicheren Checkout. Du kannst stattdessen kostenlos fortfahren.",
+    "billing": {
+      "monthly": "Monatliche Abrechnung",
+      "annual": "Jährliche Abrechnung"
+    },
+    "verified": {
+      "title": "Dein Workspace ist bestätigt",
+      "subtitle": "{{plan}} mit {{billing}} ist bereit. Wir öffnen den sicheren Checkout.",
+      "openingCheckout": "Stripe Checkout wird geöffnet…",
+      "checkoutFailed": "Der Checkout konnte nicht geöffnet werden. Dein Workspace ist im Free-Tarif aktiv und du kannst es erneut versuchen.",
+      "retryCheckout": "Checkout erneut öffnen",
+      "continueFree": "Mit Free fortfahren",
+      "freeNote": "Eine Belastung erfolgt nur, wenn du den Checkout abschließt."
+    },
     "jurisdictionLabel": "Jurisdiktion",
     "jurisdictions": {
       "eu": "EU",
@@ -2555,18 +2574,15 @@
     "plans": {
       "free": {
         "name": "Free",
-        "price": "€0",
         "description": "60 Tage Aufbewahrung, um deine Websites zu validieren, bevor du upgradest."
       },
       "pro": {
         "name": "Pro",
-        "price": "€15/Monat",
         "description": "Längere Aufbewahrung und mehr Spielraum für kleine Teams."
       },
       "business": {
         "name": "Business",
-        "price": "€39/Monat",
-        "description": "Mehr Skalierung für Agenturen, Produktteams und höheres Event-Volumen."
+        "description": "Für Agenturen mit mehreren Kunden-Websites, gemeinsamem Reporting und größeren Teams."
       }
     },
     "selfHostLink": "Du möchtest selbst hosten? Zur Dokumentation →",

--- a/frontend/dashboard/public/i18n/en.json
+++ b/frontend/dashboard/public/i18n/en.json
@@ -1667,6 +1667,11 @@
           "currentPlan": "Current plan",
           "recommended": "Recommended",
           "perMonth": "/mo",
+          "perYear": "/yr",
+          "billingLabel": "Billing interval",
+          "monthly": "Monthly",
+          "annual": "Annual",
+          "annualSaving": "2 months free",
           "openSource": {
             "note": "HitKeep is fully open source — including every paid feature. Cloud plans fund hosting and ongoing development.",
             "support": "Prefer to support us another way?",
@@ -2452,6 +2457,20 @@
   "signup": {
     "title": "Start tracking your sites for free",
     "subtitle": "Create your workspace and start tracking in under a minute. No credit card required.",
+    "paidIntentNote": "After email verification, we'll open secure checkout. You can continue on Free instead.",
+    "billing": {
+      "monthly": "Monthly billing",
+      "annual": "Annual billing"
+    },
+    "verified": {
+      "title": "Your workspace is verified",
+      "subtitle": "{{plan}} with {{billing}} is ready. We're opening secure checkout.",
+      "openingCheckout": "Opening Stripe Checkout…",
+      "checkoutFailed": "Checkout did not open. Your workspace is active on Free and you can retry safely.",
+      "retryCheckout": "Retry checkout",
+      "continueFree": "Continue on Free",
+      "freeNote": "No card is charged unless you finish checkout."
+    },
     "jurisdictionLabel": "Jurisdiction",
     "jurisdictions": {
       "eu": "EU",
@@ -2471,18 +2490,15 @@
     "plans": {
       "free": {
         "name": "Free",
-        "price": "€0",
         "description": "60-day retention to validate your sites before you upgrade."
       },
       "pro": {
         "name": "Pro",
-        "price": "€15/mo",
         "description": "Longer retention and more room for a small team."
       },
       "business": {
         "name": "Business",
-        "price": "€39/mo",
-        "description": "More scale for agencies, product teams, and higher event volume."
+        "description": "For agencies managing multiple client sites, shared reporting, and larger teams."
       }
     },
     "selfHostLink": "Want to self-host? See the docs →",

--- a/frontend/dashboard/public/i18n/es.json
+++ b/frontend/dashboard/public/i18n/es.json
@@ -1754,6 +1754,11 @@
           "currentPlan": "Plan actual",
           "recommended": "Recomendado",
           "perMonth": "/mes",
+          "perYear": "/año",
+          "billingLabel": "Periodo de facturación",
+          "monthly": "Mensual",
+          "annual": "Anual",
+          "annualSaving": "2 meses gratis",
           "openSource": {
             "note": "HitKeep es completamente de código abierto, incluidas todas las funciones de pago. Los planes cloud financian el alojamiento y el desarrollo.",
             "support": "¿Prefieres apoyarnos de otra manera?",
@@ -2536,6 +2541,20 @@
   "signup": {
     "title": "Empieza a rastrear tus sitios gratis",
     "subtitle": "Crea tu espacio de trabajo y empieza a rastrear en menos de un minuto. Sin tarjeta de crédito.",
+    "paidIntentNote": "Tras verificar el correo, abriremos el pago seguro. También puedes continuar con Free.",
+    "billing": {
+      "monthly": "Facturación mensual",
+      "annual": "Facturación anual"
+    },
+    "verified": {
+      "title": "Tu espacio de trabajo está verificado",
+      "subtitle": "{{plan}} con {{billing}} está listo. Estamos abriendo el pago seguro.",
+      "openingCheckout": "Abriendo Stripe Checkout…",
+      "checkoutFailed": "No se pudo abrir el pago. Tu espacio está activo en Free y puedes volver a intentarlo.",
+      "retryCheckout": "Reintentar el pago",
+      "continueFree": "Continuar con Free",
+      "freeNote": "No se cobra ninguna tarjeta hasta que completes el pago."
+    },
     "jurisdictionLabel": "Jurisdicción",
     "jurisdictions": {
       "eu": "EU",
@@ -2555,18 +2574,15 @@
     "plans": {
       "free": {
         "name": "Free",
-        "price": "€0",
         "description": "Retención de 60 días para validar tus sitios antes de ampliar el plan."
       },
       "pro": {
         "name": "Pro",
-        "price": "€15/mes",
         "description": "Más retención y más margen para un equipo pequeño."
       },
       "business": {
         "name": "Business",
-        "price": "€39/mes",
-        "description": "Más escala para agencias, equipos de producto y mayor volumen de eventos."
+        "description": "Para agencias con varios sitios de clientes, informes compartidos y equipos más grandes."
       }
     },
     "selfHostLink": "¿Prefieres autoalojar? Ver la documentación →",

--- a/frontend/dashboard/public/i18n/fr.json
+++ b/frontend/dashboard/public/i18n/fr.json
@@ -1754,6 +1754,11 @@
           "currentPlan": "Plan actuel",
           "recommended": "Recommandé",
           "perMonth": "/mois",
+          "perYear": "/an",
+          "billingLabel": "Période de facturation",
+          "monthly": "Mensuel",
+          "annual": "Annuel",
+          "annualSaving": "2 mois offerts",
           "openSource": {
             "note": "HitKeep est entièrement open source – y compris toutes les fonctionnalités payantes. Les offres cloud financent l'hébergement et le développement.",
             "support": "Vous préférez nous soutenir autrement ?",
@@ -2536,6 +2541,20 @@
   "signup": {
     "title": "Commencez à suivre vos sites gratuitement",
     "subtitle": "Créez votre espace de travail et commencez le suivi en moins d'une minute. Aucune carte bancaire requise.",
+    "paidIntentNote": "Après vérification de l'e-mail, nous ouvrirons le paiement sécurisé. Vous pouvez aussi continuer avec Free.",
+    "billing": {
+      "monthly": "Facturation mensuelle",
+      "annual": "Facturation annuelle"
+    },
+    "verified": {
+      "title": "Votre espace de travail est vérifié",
+      "subtitle": "{{plan}} avec {{billing}} est prêt. Nous ouvrons le paiement sécurisé.",
+      "openingCheckout": "Ouverture de Stripe Checkout…",
+      "checkoutFailed": "Le paiement ne s'est pas ouvert. Votre espace est actif sur Free et vous pouvez réessayer.",
+      "retryCheckout": "Réessayer le paiement",
+      "continueFree": "Continuer avec Free",
+      "freeNote": "Aucune carte n'est débitée tant que vous ne terminez pas le paiement."
+    },
     "jurisdictionLabel": "Juridiction",
     "jurisdictions": {
       "eu": "EU",
@@ -2555,18 +2574,15 @@
     "plans": {
       "free": {
         "name": "Free",
-        "price": "€0",
         "description": "60 jours de rétention pour valider vos sites avant une montée en gamme."
       },
       "pro": {
         "name": "Pro",
-        "price": "€15/mois",
         "description": "Plus de rétention et plus de marge pour une petite équipe."
       },
       "business": {
         "name": "Business",
-        "price": "€39/mois",
-        "description": "Plus d'échelle pour les agences, les équipes produit et un volume d'événements plus élevé."
+        "description": "Pour les agences qui gèrent plusieurs sites clients, des rapports partagés et de grandes équipes."
       }
     },
     "selfHostLink": "Vous préférez héberger vous-même ? Voir la documentation →",

--- a/frontend/dashboard/public/i18n/it.json
+++ b/frontend/dashboard/public/i18n/it.json
@@ -1754,6 +1754,11 @@
           "currentPlan": "Piano attuale",
           "recommended": "Consigliato",
           "perMonth": "/mese",
+          "perYear": "/anno",
+          "billingLabel": "Periodo di fatturazione",
+          "monthly": "Mensile",
+          "annual": "Annuale",
+          "annualSaving": "2 mesi gratis",
           "openSource": {
             "note": "HitKeep è completamente open source, incluse tutte le funzionalità a pagamento. I piani cloud finanziano hosting e sviluppo.",
             "support": "Preferisci sostenerci in un altro modo?",
@@ -2536,6 +2541,20 @@
   "signup": {
     "title": "Inizia a tracciare i tuoi siti gratis",
     "subtitle": "Crea il tuo workspace e inizia il tracciamento in meno di un minuto. Nessuna carta di credito richiesta.",
+    "paidIntentNote": "Dopo la verifica dell'e-mail apriremo il pagamento sicuro. Puoi anche continuare con Free.",
+    "billing": {
+      "monthly": "Fatturazione mensile",
+      "annual": "Fatturazione annuale"
+    },
+    "verified": {
+      "title": "Il tuo workspace è verificato",
+      "subtitle": "{{plan}} con {{billing}} è pronto. Stiamo aprendo il pagamento sicuro.",
+      "openingCheckout": "Apertura di Stripe Checkout…",
+      "checkoutFailed": "Il pagamento non si è aperto. Il workspace è attivo su Free e puoi riprovare.",
+      "retryCheckout": "Riprova il pagamento",
+      "continueFree": "Continua con Free",
+      "freeNote": "La carta viene addebitata solo se completi il pagamento."
+    },
     "jurisdictionLabel": "Giurisdizione",
     "jurisdictions": {
       "eu": "EU",
@@ -2555,18 +2574,15 @@
     "plans": {
       "free": {
         "name": "Free",
-        "price": "€0",
         "description": "Retenzione di 60 giorni per validare i tuoi siti prima di passare a un piano superiore."
       },
       "pro": {
         "name": "Pro",
-        "price": "€15/mese",
         "description": "Più retention e più margine per un piccolo team."
       },
       "business": {
         "name": "Business",
-        "price": "€39/mese",
-        "description": "Più scala per agenzie, team di prodotto e volumi di eventi più alti."
+        "description": "Per agenzie con più siti cliente, report condivisi e team più grandi."
       }
     },
     "selfHostLink": "Preferisci il self-hosting? Vedi la documentazione →",

--- a/frontend/dashboard/public/i18n/nl.json
+++ b/frontend/dashboard/public/i18n/nl.json
@@ -1736,6 +1736,11 @@
           "currentPlan": "Huidig ​​abonnement",
           "recommended": "Aanbevolen",
           "perMonth": "/mnd",
+          "perYear": "/jaar",
+          "billingLabel": "Factureringsperiode",
+          "monthly": "Maandelijks",
+          "annual": "Jaarlijks",
+          "annualSaving": "2 maanden gratis",
           "openSource": {
             "note": "HitKeep is volledig open source – inclusief alle betaalde functies. Cloudabonnementen financieren hosting en ontwikkeling.",
             "support": "Wil je ons liever op een andere manier steunen?",
@@ -2518,6 +2523,20 @@
   "signup": {
     "title": "Begin gratis met het volgen van je sites",
     "subtitle": "Creëer je werkruimte en begin binnen een minuut met volgen. Geen creditcard vereist.",
+    "paidIntentNote": "Na e-mailverificatie openen we de beveiligde checkout. Je kunt ook doorgaan met Free.",
+    "billing": {
+      "monthly": "Maandelijkse facturering",
+      "annual": "Jaarlijkse facturering"
+    },
+    "verified": {
+      "title": "Je werkruimte is geverifieerd",
+      "subtitle": "{{plan}} met {{billing}} staat klaar. We openen de beveiligde checkout.",
+      "openingCheckout": "Stripe Checkout wordt geopend…",
+      "checkoutFailed": "De checkout kon niet worden geopend. Je werkruimte is actief op Free en je kunt het opnieuw proberen.",
+      "retryCheckout": "Checkout opnieuw proberen",
+      "continueFree": "Doorgaan met Free",
+      "freeNote": "Je kaart wordt pas belast als je de checkout afrondt."
+    },
     "jurisdictionLabel": "Jurisdictie",
     "jurisdictions": {
       "eu": "EU",
@@ -2537,18 +2556,15 @@
     "plans": {
       "free": {
         "name": "Vrij",
-        "price": "€ 0",
         "description": "Retentie van 60 dagen om je sites te valideren voordat je een upgrade uitvoert."
       },
       "pro": {
         "name": "Pro",
-        "price": "€ 15/maand",
         "description": "Langere retentie en meer ruimte voor een klein team."
       },
       "business": {
         "name": "Bedrijf",
-        "price": "€ 39/maand",
-        "description": "Meer schaalgrootte voor bureaus, productteams en een hoger evenementenvolume."
+        "description": "Voor bureaus met meerdere klantsites, gedeelde rapportages en grotere teams."
       }
     },
     "selfHostLink": "Wil je zelf hosten? Zie de documenten →",

--- a/frontend/dashboard/public/i18n/pt.json
+++ b/frontend/dashboard/public/i18n/pt.json
@@ -1747,6 +1747,11 @@
           "currentPlan": "Plano atual",
           "recommended": "Recomendado",
           "perMonth": "/mês",
+          "perYear": "/ano",
+          "billingLabel": "Período de cobrança",
+          "monthly": "Mensal",
+          "annual": "Anual",
+          "annualSaving": "2 meses grátis",
           "openSource": {
             "note": "O HitKeep é totalmente open source – incluindo todos os recursos pagos. Os planos cloud financiam a hospedagem e o desenvolvimento.",
             "support": "Prefere nos apoiar de outra forma?",
@@ -2512,6 +2517,20 @@
   "signup": {
     "title": "Comece a rastrear seus sites gratuitamente",
     "subtitle": "Crie seu espaço de trabalho e comece a rastrear em menos de um minuto. Não é necessário cartão de crédito.",
+    "paidIntentNote": "Após verificar o e-mail, abriremos o checkout seguro. Você também pode continuar no Free.",
+    "billing": {
+      "monthly": "Cobrança mensal",
+      "annual": "Cobrança anual"
+    },
+    "verified": {
+      "title": "Seu espaço de trabalho foi verificado",
+      "subtitle": "{{plan}} com {{billing}} está pronto. Estamos abrindo o checkout seguro.",
+      "openingCheckout": "Abrindo o Stripe Checkout…",
+      "checkoutFailed": "O checkout não abriu. Seu espaço está ativo no Free e você pode tentar novamente.",
+      "retryCheckout": "Tentar checkout novamente",
+      "continueFree": "Continuar no Free",
+      "freeNote": "O cartão só será cobrado se você concluir o checkout."
+    },
     "jurisdictionLabel": "Jurisdição",
     "jurisdictions": {
       "eu": "UE",
@@ -2531,18 +2550,15 @@
     "plans": {
       "free": {
         "name": "Gratuito",
-        "price": "€0",
         "description": "Retenção de 60 dias para validar seus sites antes de fazer o upgrade."
       },
       "pro": {
         "name": "Pro",
-        "price": "€15/mês",
         "description": "Maior período de retenção e mais espaço para uma equipe pequena."
       },
       "business": {
         "name": "Business",
-        "price": "€39/mês",
-        "description": "Mais escala para agências, equipes de produto e maior volume de eventos."
+        "description": "Para agências com vários sites de clientes, relatórios compartilhados e equipes maiores."
       }
     },
     "selfHostLink": "Quer fazer self-host? Consulte a documentação →",

--- a/frontend/dashboard/src/app/app.routes.ts
+++ b/frontend/dashboard/src/app/app.routes.ts
@@ -31,6 +31,12 @@ export const routes: Routes = [
         data: titleData('signup.title')
     },
     {
+        path: 'signup/verified',
+        loadComponent: () => import('@pages/signup/verified-signup').then((m) => m.VerifiedSignup),
+        canActivate: [setupGuard, authGuard],
+        data: titleData('signup.verified.title')
+    },
+    {
         path: 'forgot-password',
         loadComponent: () => import('@pages/password/forgot-password').then((m) => m.ForgotPassword),
         data: titleData('password.forgot.title')
@@ -213,25 +219,37 @@ export const routes: Routes = [
                         path: 'filtering',
                         loadComponent: () => import('@pages/site-settings/site-filtering-settings-page').then((m) => m.SiteFilteringSettingsPage),
                         canActivate: [siteSettingsSectionGuard],
-                        data: { ...titleData('sites.settings.tabs.filtering', 'site'), siteSettingsSection: 'filtering' }
+                        data: {
+                            ...titleData('sites.settings.tabs.filtering', 'site'),
+                            siteSettingsSection: 'filtering'
+                        }
                     },
                     {
                         path: 'retention',
                         loadComponent: () => import('@pages/site-settings/site-retention-settings-page').then((m) => m.SiteRetentionSettingsPage),
                         canActivate: [siteSettingsSectionGuard],
-                        data: { ...titleData('sites.settings.tabs.retention', 'site'), siteSettingsSection: 'retention' }
+                        data: {
+                            ...titleData('sites.settings.tabs.retention', 'site'),
+                            siteSettingsSection: 'retention'
+                        }
                     },
                     {
                         path: 'access',
                         loadComponent: () => import('@pages/site-settings/site-access-settings-page').then((m) => m.SiteAccessSettingsPage),
                         canActivate: [siteSettingsSectionGuard],
-                        data: { ...titleData('sites.settings.tabs.access', 'site'), siteSettingsSection: 'access' }
+                        data: {
+                            ...titleData('sites.settings.tabs.access', 'site'),
+                            siteSettingsSection: 'access'
+                        }
                     },
                     {
                         path: 'danger-zone',
                         loadComponent: () => import('@pages/site-settings/site-danger-zone-page').then((m) => m.SiteDangerZonePage),
                         canActivate: [siteSettingsSectionGuard],
-                        data: { ...titleData('sites.settings.tabs.dangerZone', 'site'), siteSettingsSection: 'danger-zone' }
+                        data: {
+                            ...titleData('sites.settings.tabs.dangerZone', 'site'),
+                            siteSettingsSection: 'danger-zone'
+                        }
                     }
                 ]
             },
@@ -258,7 +276,10 @@ export const routes: Routes = [
                 path: 'integration/google-search-console',
                 loadComponent: () => import('@pages/integration/google-search-console/google-search-console').then((m) => m.GoogleSearchConsolePage),
                 canActivate: [capabilityGuard],
-                data: { ...titleData('nav.googleSearchConsole', 'team'), activeTeamCapability: TEAM_CAPABILITIES.manageIntegrations }
+                data: {
+                    ...titleData('nav.googleSearchConsole', 'team'),
+                    activeTeamCapability: TEAM_CAPABILITIES.manageIntegrations
+                }
             },
             {
                 path: 'import-export',
@@ -290,13 +311,21 @@ export const routes: Routes = [
                         path: 'status',
                         loadComponent: () => import('@pages/admin/admin-settings').then((m) => m.AdminSettings),
                         canActivate: [capabilityGuard],
-                        data: { ...titleData('nav.systemStatus'), adminPage: 'status', instanceCapability: INSTANCE_CAPABILITIES.viewSystem }
+                        data: {
+                            ...titleData('nav.systemStatus'),
+                            adminPage: 'status',
+                            instanceCapability: INSTANCE_CAPABILITIES.viewSystem
+                        }
                     },
                     {
                         path: 'system',
                         loadComponent: () => import('@pages/admin/admin-settings').then((m) => m.AdminSettings),
                         canActivate: [capabilityGuard],
-                        data: { ...titleData('nav.systemSettings'), adminPage: 'settings', instanceCapability: INSTANCE_CAPABILITIES.manageUsers }
+                        data: {
+                            ...titleData('nav.systemSettings'),
+                            adminPage: 'settings',
+                            instanceCapability: INSTANCE_CAPABILITIES.manageUsers
+                        }
                     },
                     {
                         path: 'team',
@@ -321,7 +350,10 @@ export const routes: Routes = [
                                     {
                                         path: 'invite',
                                         loadComponent: () => import('@pages/admin/team/team-members').then((m) => m.TeamMembersPage),
-                                        data: { ...titleData('admin.team.tabs.members', 'team'), openInvite: true }
+                                        data: {
+                                            ...titleData('admin.team.tabs.members', 'team'),
+                                            openInvite: true
+                                        }
                                     }
                                 ]
                             },
@@ -349,15 +381,26 @@ export const routes: Routes = [
                                 path: 'activity',
                                 loadComponent: () => import('@pages/admin/team/team-audit').then((m) => m.TeamAuditPage),
                                 canActivate: [capabilityGuard],
-                                data: { ...titleData('admin.team.tabs.activity', 'team'), activeTeamCapability: TEAM_CAPABILITIES.viewAudit }
+                                data: {
+                                    ...titleData('admin.team.tabs.activity', 'team'),
+                                    activeTeamCapability: TEAM_CAPABILITIES.viewAudit
+                                }
                             },
                             {
                                 path: 'danger-zone',
                                 loadComponent: () => import('@pages/admin/team/team-danger-zone').then((m) => m.TeamDangerZonePage),
                                 data: titleData('admin.team.tabs.dangerZone', 'team')
                             },
-                            { path: 'settings', pathMatch: 'full', redirectTo: 'api-clients' },
-                            { path: 'tracking-domains', pathMatch: 'full', redirectTo: 'custom-domains' }
+                            {
+                                path: 'settings',
+                                pathMatch: 'full',
+                                redirectTo: 'api-clients'
+                            },
+                            {
+                                path: 'tracking-domains',
+                                pathMatch: 'full',
+                                redirectTo: 'custom-domains'
+                            }
                         ]
                     },
                     { path: '', redirectTo: 'team', pathMatch: 'full' }

--- a/frontend/dashboard/src/app/core/services/cloud.service.ts
+++ b/frontend/dashboard/src/app/core/services/cloud.service.ts
@@ -4,11 +4,15 @@ import { Observable } from 'rxjs';
 
 import { CloudPlanTier } from '@models/analytics.types';
 
+export type CloudPlanCode = 'free' | 'pro' | 'business';
+export type BillingInterval = 'monthly' | 'annual';
+
 export interface CloudSignupRequest {
     email: string;
     password: string;
     team_name: string;
-    plan_code: 'free' | 'pro' | 'business';
+    plan_code: CloudPlanCode;
+    billing: BillingInterval;
     jurisdiction?: string;
     locale?: string;
     given_name?: string;
@@ -19,6 +23,7 @@ export interface CloudSignupRequest {
 export interface CloudSignupResponse {
     status: string;
     plan_code: string;
+    billing: BillingInterval;
     redirect_url?: string;
     checkout_url?: string;
 }
@@ -33,6 +38,7 @@ export interface BillingPortalSessionRequest {
 
 export interface BillingCheckoutSessionRequest {
     plan_code: 'pro' | 'business';
+    billing: BillingInterval;
     locale?: string;
 }
 

--- a/frontend/dashboard/src/app/pages/admin/team/team-overview.css
+++ b/frontend/dashboard/src/app/pages/admin/team/team-overview.css
@@ -15,6 +15,42 @@
     background: linear-gradient(180deg, color-mix(in srgb, var(--p-primary-color) 5%, var(--p-content-background)) 0%, var(--p-content-background) 40%);
 }
 
+.plan-comparison__billing {
+    display: inline-flex;
+    align-self: flex-start;
+    gap: 0.25rem;
+    padding: 0.25rem;
+    border: 1px solid var(--p-content-border-color);
+    border-radius: 0.75rem;
+    background: var(--p-content-background);
+}
+
+.plan-comparison__billing button {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.4rem;
+    min-height: 2.25rem;
+    padding: 0.45rem 0.75rem;
+    border: 0;
+    border-radius: 0.55rem;
+    background: transparent;
+    color: var(--p-text-muted-color);
+    font: inherit;
+    font-size: 0.875rem;
+    font-weight: 600;
+    cursor: pointer;
+}
+
+.plan-comparison__billing button[aria-pressed="true"] {
+    background: color-mix(in srgb, var(--p-primary-color) 12%, var(--p-content-background));
+    color: var(--p-text-color);
+}
+
+.plan-comparison__billing button span {
+    color: var(--p-primary-color);
+    font-size: 0.75rem;
+}
+
 :host ::ng-deep .team-overview__usage-card .p-progressbar {
     height: 0.65rem;
 }

--- a/frontend/dashboard/src/app/pages/admin/team/team-overview.html
+++ b/frontend/dashboard/src/app/pages/admin/team/team-overview.html
@@ -68,6 +68,13 @@
                 <h4 class="m-0 text-base font-bold">{{ "admin.team.overview.plans.title" | transloco }}</h4>
                 <p class="m-0 text-sm text-[var(--p-text-muted-color)]">{{ "admin.team.overview.plans.description" | transloco }}</p>
             </div>
+            <div class="plan-comparison__billing" role="group" [attr.aria-label]="'admin.team.overview.plans.billingLabel' | transloco">
+                <button type="button" [attr.aria-pressed]="billingInterval() === 'monthly'" (click)="billingInterval.set('monthly')">{{ "admin.team.overview.plans.monthly" | transloco }}</button>
+                <button type="button" [attr.aria-pressed]="billingInterval() === 'annual'" (click)="billingInterval.set('annual')">
+                    {{ "admin.team.overview.plans.annual" | transloco }}
+                    <span>{{ "admin.team.overview.plans.annualSaving" | transloco }}</span>
+                </button>
+            </div>
             <div class="grid grid-cols-[repeat(auto-fit,minmax(16rem,1fr))] gap-4">
                 @if (currentTier(); as current) {
                 <p-card styleClass="hk-card plan-comparison__card--current">
@@ -79,7 +86,7 @@
                         <span class="flex items-baseline gap-1">
                             <span class="text-3xl font-extrabold">{{ planPriceLabels()[current.code] }}</span>
                             @if (current.code !== "free") {
-                            <span class="text-sm font-semibold text-[var(--p-text-muted-color)]">{{ "admin.team.overview.plans.perMonth" | transloco }}</span>
+                            <span class="text-sm font-semibold text-[var(--p-text-muted-color)]">{{ (billingInterval() === "annual" ? "admin.team.overview.plans.perYear" : "admin.team.overview.plans.perMonth") | transloco }}</span>
                             }
                         </span>
                         <p class="mt-1 mb-0 text-sm text-[var(--p-text-muted-color)]">{{ ("signup.plans." + current.code + ".description") | transloco }}</p>
@@ -111,7 +118,7 @@
                         </div>
                         <span class="flex items-baseline gap-1">
                             <span class="text-3xl font-extrabold">{{ planPriceLabels()[tier.code] }}</span>
-                            <span class="text-sm font-semibold text-[var(--p-text-muted-color)]">{{ "admin.team.overview.plans.perMonth" | transloco }}</span>
+                            <span class="text-sm font-semibold text-[var(--p-text-muted-color)]">{{ (billingInterval() === "annual" ? "admin.team.overview.plans.perYear" : "admin.team.overview.plans.perMonth") | transloco }}</span>
                         </span>
                         <p class="mt-1 mb-0 text-sm text-[var(--p-text-muted-color)]">{{ ("signup.plans." + tier.code + ".description") | transloco }}</p>
                     </div>
@@ -160,7 +167,9 @@
                 <p class="m-0">
                     {{ "admin.team.overview.plans.openSource.support" | transloco }}
                     <a href="https://hitkeep.com/support/funding/" target="_blank" rel="noreferrer" class="font-semibold text-primary no-underline hover:underline">{{ "admin.team.overview.plans.openSource.sponsor" | transloco }}</a>
-                    · <a href="https://x.com/gethitkeep" target="_blank" rel="noreferrer" class="font-semibold text-primary no-underline hover:underline">X</a> ·
+                    ·
+                    <a href="https://x.com/gethitkeep" target="_blank" rel="noreferrer" class="font-semibold text-primary no-underline hover:underline">X</a>
+                    ·
                     <a href="https://www.linkedin.com/company/hitkeep" target="_blank" rel="noreferrer" class="font-semibold text-primary no-underline hover:underline">LinkedIn</a>
                     · {{ "admin.team.overview.plans.openSource.spread" | transloco }}
                 </p>

--- a/frontend/dashboard/src/app/pages/admin/team/team-overview.spec.ts
+++ b/frontend/dashboard/src/app/pages/admin/team/team-overview.spec.ts
@@ -146,9 +146,18 @@ describe('TeamOverviewPage', () => {
                             teams: { roles: { owner: 'Owner' } },
                             signup: {
                                 plans: {
-                                    free: { name: 'Free', price: '€0', description: '60-day retention to validate your sites.' },
-                                    pro: { name: 'Pro', price: '€15/mo', description: 'Longer retention and more room for a small team.' },
-                                    business: { name: 'Business', price: '€39/mo', description: 'More scale for agencies.' }
+                                    free: {
+                                        name: 'Free',
+                                        description: '60-day retention to validate your sites.'
+                                    },
+                                    pro: {
+                                        name: 'Pro',
+                                        description: 'Longer retention and more room for a small team.'
+                                    },
+                                    business: {
+                                        name: 'Business',
+                                        description: 'More scale for agencies.'
+                                    }
                                 }
                             }
                         }
@@ -183,17 +192,35 @@ describe('TeamOverviewPage', () => {
                                 {
                                     code: 'free',
                                     name: 'Free',
-                                    entitlements: { max_sites_per_team: 3, max_team_members: 3, max_retention_days: 60, allow_sso: false, allow_custom_branding: false }
+                                    entitlements: {
+                                        max_sites_per_team: 3,
+                                        max_team_members: 3,
+                                        max_retention_days: 60,
+                                        allow_sso: false,
+                                        allow_custom_branding: false
+                                    }
                                 },
                                 {
                                     code: 'pro',
                                     name: 'Pro',
-                                    entitlements: { max_sites_per_team: 10, max_team_members: 5, max_retention_days: 365, allow_sso: false, allow_custom_branding: false }
+                                    entitlements: {
+                                        max_sites_per_team: 10,
+                                        max_team_members: 5,
+                                        max_retention_days: 365,
+                                        allow_sso: false,
+                                        allow_custom_branding: false
+                                    }
                                 },
                                 {
                                     code: 'business',
                                     name: 'Business',
-                                    entitlements: { max_sites_per_team: 50, max_team_members: 20, max_retention_days: 1095, allow_sso: true, allow_custom_branding: true }
+                                    entitlements: {
+                                        max_sites_per_team: 50,
+                                        max_team_members: 20,
+                                        max_retention_days: 1095,
+                                        allow_sso: true,
+                                        allow_custom_branding: true
+                                    }
                                 }
                             ])
                         )
@@ -250,6 +277,27 @@ describe('TeamOverviewPage', () => {
         expect(text).toContain('Upgrade to Pro');
         expect(text).toContain('Upgrade to Business');
         expect(text).toContain('Single sign-on (SSO)');
+        expect(text).toContain('€150');
+        expect(text).toContain('€390');
+    });
+
+    it('formats the same annual tiers in USD for the US jurisdiction', async () => {
+        fixture.destroy();
+        systemStatusResponse.cloud = {
+            ...systemStatusResponse.cloud!,
+            jurisdiction: 'US',
+            region: 'us-east-1'
+        };
+
+        fixture = TestBed.createComponent(TeamOverviewPage);
+        fixture.detectChanges();
+        await fixture.whenStable();
+        fixture.detectChanges();
+
+        const text = fixture.nativeElement.textContent;
+        expect(text).toContain('$150');
+        expect(text).toContain('$390');
+        expect(text).not.toContain('€150');
     });
 
     it('renders Business with SSO as the next upgrade for Pro users', async () => {
@@ -309,7 +357,9 @@ describe('TeamOverviewPage', () => {
 
         component.openBillingPortal();
 
-        expect(cloudService.createBillingPortalSession).toHaveBeenCalledWith({ locale: 'en' });
+        expect(cloudService.createBillingPortalSession).toHaveBeenCalledWith({
+            locale: 'en'
+        });
         expect(redirectSpy).toHaveBeenCalledWith('https://billing.stripe.test/session');
     });
 
@@ -320,7 +370,11 @@ describe('TeamOverviewPage', () => {
 
         component.startUpgradeCheckout();
 
-        expect(cloudService.createBillingCheckoutSession).toHaveBeenCalledWith({ plan_code: 'pro', locale: 'en' });
+        expect(cloudService.createBillingCheckoutSession).toHaveBeenCalledWith({
+            plan_code: 'pro',
+            billing: 'annual',
+            locale: 'en'
+        });
         expect(redirectSpy).toHaveBeenCalledWith('https://checkout.stripe.test/session');
     });
 

--- a/frontend/dashboard/src/app/pages/admin/team/team-overview.ts
+++ b/frontend/dashboard/src/app/pages/admin/team/team-overview.ts
@@ -10,13 +10,16 @@ import { CopyControl } from '@components/copy-control/copy-control';
 import { TeamService } from '@services/team.service';
 import { injectActiveLang } from '@core/i18n/active-lang';
 import { AnalyticsService } from '@services/analytics.service';
-import { CloudService } from '@services/cloud.service';
+import { BillingInterval, CloudService } from '@services/cloud.service';
 import { firstValueFrom } from 'rxjs';
 
 import { CloudPlanTier, TeamPlan, TeamRole } from '@models/analytics.types';
 
-/** Monthly EUR list prices per cloud plan; formatted locale-aware at render time. */
-const PLAN_MONTHLY_PRICES_EUR: Record<string, number> = { free: 0, pro: 15, business: 39 };
+/** Canonical regional list-price amounts; EUR and USD use the same numeric tiers. */
+const PLAN_PRICES: Record<BillingInterval, Record<string, number>> = {
+    monthly: { free: 0, pro: 15, business: 39 },
+    annual: { free: 0, pro: 150, business: 390 }
+};
 const PLAN_RANK: Record<string, number> = { free: 0, pro: 1, business: 2 };
 
 @Component({
@@ -43,6 +46,7 @@ export class TeamOverviewPage {
     protected readonly planTiers = signal<CloudPlanTier[]>([]);
     protected readonly portalPending = signal(false);
     protected readonly checkoutPending = signal(false);
+    protected readonly billingInterval = signal<BillingInterval>('annual');
     protected readonly usageCards = computed(() => {
         const team = this.team();
         const cloud = this.systemStatus()?.cloud;
@@ -82,12 +86,14 @@ export class TeamOverviewPage {
         return this.planTiers().filter((tier) => (PLAN_RANK[tier.code] ?? -1) > currentRank);
     });
     protected readonly showPlanComparison = computed(() => this.upgradeTiers().length > 0);
-    /** Locale-aware plan prices, e.g. "€15" in English and "15 €" in German. */
+    protected readonly planCurrency = computed<'EUR' | 'USD'>(() => (this.systemStatus()?.cloud?.jurisdiction?.trim().toUpperCase() === 'US' ? 'USD' : 'EUR'));
+    /** Locale-aware regional plan prices, e.g. "€150" or "$150". */
     protected readonly planPriceLabels = computed<Record<string, string>>(() => {
         this.activeLanguage();
+        const currency = this.planCurrency();
         const labels: Record<string, string> = {};
-        for (const [code, amount] of Object.entries(PLAN_MONTHLY_PRICES_EUR)) {
-            labels[code] = this.localeService.localizeNumber(amount, 'currency', undefined, { currency: 'EUR', minimumFractionDigits: 0, maximumFractionDigits: 0 });
+        for (const [code, amount] of Object.entries(PLAN_PRICES[this.billingInterval()])) {
+            labels[code] = this.localeService.localizeNumber(amount, 'currency', undefined, { currency, minimumFractionDigits: 0, maximumFractionDigits: 0 });
         }
         return labels;
     });
@@ -123,14 +129,18 @@ export class TeamOverviewPage {
     }
 
     protected usageDescription(current: number): string {
-        return this.transloco.translate('admin.team.overview.usage.currentUsage', { count: current });
+        return this.transloco.translate('admin.team.overview.usage.currentUsage', {
+            count: current
+        });
     }
 
     protected usageLimitLabel(limit: number): string {
         if (limit <= 0) {
             return this.transloco.translate('admin.team.overview.usage.unlimited');
         }
-        return this.transloco.translate('admin.team.overview.usage.limitValue', { count: limit });
+        return this.transloco.translate('admin.team.overview.usage.limitValue', {
+            count: limit
+        });
     }
 
     protected usageStateClass(percentage: number, limit: number): string {
@@ -157,7 +167,9 @@ export class TeamOverviewPage {
         if (days <= 0) {
             return this.transloco.translate('admin.team.overview.cloud.unlimitedRetention');
         }
-        return this.transloco.translate('admin.team.overview.cloud.retentionDays', { count: days });
+        return this.transloco.translate('admin.team.overview.cloud.retentionDays', {
+            count: days
+        });
     }
 
     protected planName(plan: TeamPlan): string {
@@ -203,7 +215,11 @@ export class TeamOverviewPage {
 
         this.checkoutPending.set(true);
         this.cloudService
-            .createBillingCheckoutSession({ plan_code: planCode, locale: this.activeLanguage() })
+            .createBillingCheckoutSession({
+                plan_code: planCode,
+                billing: this.billingInterval(),
+                locale: this.activeLanguage()
+            })
             .pipe(takeUntilDestroyed(this.destroyRef))
             .subscribe({
                 next: ({ url }) => {
@@ -223,7 +239,11 @@ export class TeamOverviewPage {
 
         this.checkoutPending.set(true);
         this.cloudService
-            .createBillingCheckoutSession({ plan_code: 'pro', locale: this.activeLanguage() })
+            .createBillingCheckoutSession({
+                plan_code: 'pro',
+                billing: this.billingInterval(),
+                locale: this.activeLanguage()
+            })
             .pipe(takeUntilDestroyed(this.destroyRef))
             .subscribe({
                 next: ({ url }) => {

--- a/frontend/dashboard/src/app/pages/signup/signup.html
+++ b/frontend/dashboard/src/app/pages/signup/signup.html
@@ -19,6 +19,12 @@
             <form (submit)="onSubmit($event)" class="hk-auth-form" novalidate>
                 @if (errorMessage(); as errorMessageKey) {
                 <p-message severity="error" role="alert" aria-live="assertive">{{ errorMessageKey | transloco }}</p-message>
+                } @if (selectedPlan() !== "free") {
+                <div class="rounded-lg border border-primary/20 bg-primary/5 px-4 py-3 text-sm" data-testid="signup-paid-intent">
+                    <span class="font-semibold">{{ ("signup.plans." + selectedPlan() + ".name") | transloco }}</span>
+                    <span class="text-[var(--p-text-muted-color)]"> · {{ ("signup.billing." + selectedBilling()) | transloco }}</span>
+                    <p class="mt-1 mb-0 text-[var(--p-text-muted-color)]">{{ "signup.paidIntentNote" | transloco }}</p>
+                </div>
                 }
 
                 <p-fieldset [dt]="jurisdictionFieldsetDesignTokens">

--- a/frontend/dashboard/src/app/pages/signup/signup.spec.ts
+++ b/frontend/dashboard/src/app/pages/signup/signup.spec.ts
@@ -136,13 +136,20 @@ describe('Signup', () => {
     it('tracks the signup page view when hosted signup is available', () => {
         expect(signupTrackingMock.trackEvent).toHaveBeenCalledWith('signup_page_view', {
             jurisdiction: 'EU',
-            plan_code: 'free',
+            plan: 'free',
+            interval: 'monthly',
             source_path: '/signup'
         });
     });
 
     it('submits a cloud signup request with free plan', () => {
-        cloudServiceMock.signup.mockReturnValue(of({ status: 'verification_sent', plan_code: 'free' } as CloudSignupResponse));
+        cloudServiceMock.signup.mockReturnValue(
+            of({
+                status: 'verification_sent',
+                plan_code: 'free',
+                billing: 'monthly'
+            } as CloudSignupResponse)
+        );
 
         component['signupForm'].teamName().control().setValue('Cloud Team');
         component['signupForm'].email().control().setValue('user@example.com');
@@ -155,20 +162,52 @@ describe('Signup', () => {
         expect(payload?.['team_name']).toBe('Cloud Team');
         expect(payload?.['email']).toBe('user@example.com');
         expect(payload?.['plan_code']).toBe('free');
+        expect(payload?.['billing']).toBe('monthly');
         expect(payload?.['jurisdiction']).toBe('EU');
         expect(payload?.['locale']).toBe('en');
         expect(payload?.['accepted_tos']).toBe(true);
         expect(signupTrackingMock.trackEvent).toHaveBeenCalledWith('signup_started', {
             jurisdiction: 'EU',
-            plan_code: 'free',
+            plan: 'free',
+            interval: 'monthly',
             source_path: '/signup'
         });
         expect(signupTrackingMock.trackEvent).toHaveBeenCalledWith('signup_completed_candidate', {
             jurisdiction: 'EU',
-            plan_code: 'free',
+            plan: 'free',
+            interval: 'monthly',
             source_path: '/signup',
             response_status: 'verification_sent'
         });
+    });
+
+    it('hydrates and submits paid annual intent from query params', () => {
+        queryParams = {
+            plan: 'business',
+            billing: 'annual'
+        };
+        cloudServiceMock.signup.mockReturnValue(
+            of({
+                status: 'verification_sent',
+                plan_code: 'business',
+                billing: 'annual'
+            } as CloudSignupResponse)
+        );
+
+        fixture = TestBed.createComponent(Signup);
+        component = fixture.componentInstance;
+        fixture.detectChanges();
+        component['signupForm'].teamName().control().setValue('Agency Team');
+        component['signupForm'].email().control().setValue('agency@example.com');
+        component['signupForm'].password().control().setValue('password123');
+        component['signupForm'].acceptedTos().control().setValue(true);
+
+        component['onSubmit']();
+
+        const payload = cloudServiceMock.signup.mock.calls.at(-1)?.[0] as Record<string, unknown> | undefined;
+        expect(payload?.['plan_code']).toBe('business');
+        expect(payload?.['billing']).toBe('annual');
+        expect(signupTrackingMock.trackEvent.mock.calls.some(([name, properties]) => name === 'signup_started' && properties?.plan === 'business' && properties?.interval === 'annual')).toBe(true);
     });
 
     it('does not discover or offer enterprise SSO from public signup', () => {
@@ -199,6 +238,8 @@ describe('Signup', () => {
             region: 'EU',
             utm_source: 'hitkeep_docs',
             utm_campaign: 'agency_pilot',
+            plan: 'business',
+            billing: 'annual',
             error: 'exists'
         };
         fixture = TestBed.createComponent(Signup);
@@ -216,13 +257,20 @@ describe('Signup', () => {
         expect(href).toContain('email=user%40example.com');
         expect(href).toContain('utm_source=hitkeep_docs');
         expect(href).toContain('utm_campaign=agency_pilot');
+        expect(href).toContain('plan=business');
+        expect(href).toContain('billing=annual');
         expect(href).not.toContain('region=');
         expect(href).not.toContain('error=');
         expect(href).not.toContain('password123');
     });
 
     it('does nothing when the selected jurisdiction is already active', () => {
-        const redirectSpy = vi.spyOn(component as unknown as { redirectToJurisdiction: (jurisdiction: 'EU' | 'US') => void }, 'redirectToJurisdiction');
+        const redirectSpy = vi.spyOn(
+            component as unknown as {
+                redirectToJurisdiction: (jurisdiction: 'EU' | 'US') => void;
+            },
+            'redirectToJurisdiction'
+        );
 
         component['selectJurisdiction']('EU');
 
@@ -230,13 +278,21 @@ describe('Signup', () => {
     });
 
     it('tracks and redirects when selecting the alternate region', () => {
-        const redirectSpy = vi.spyOn(component as unknown as { redirectToJurisdiction: (jurisdiction: 'EU' | 'US') => void }, 'redirectToJurisdiction').mockImplementation(() => undefined);
+        const redirectSpy = vi
+            .spyOn(
+                component as unknown as {
+                    redirectToJurisdiction: (jurisdiction: 'EU' | 'US') => void;
+                },
+                'redirectToJurisdiction'
+            )
+            .mockImplementation(() => undefined);
 
         component['selectJurisdiction']('US');
 
         expect(signupTrackingMock.trackEvent).toHaveBeenCalledWith('cloud_region_switch_click', {
             jurisdiction: 'EU',
-            plan_code: 'free',
+            plan: 'free',
+            interval: 'monthly',
             source_path: '/signup',
             target_jurisdiction: 'US'
         });

--- a/frontend/dashboard/src/app/pages/signup/signup.ts
+++ b/frontend/dashboard/src/app/pages/signup/signup.ts
@@ -21,7 +21,7 @@ import { injectActiveLang } from '@core/i18n/active-lang';
 import { CloudStatus } from '@models/analytics.types';
 import { AnalyticsService } from '@services/analytics.service';
 import { CloudSignupTrackingService } from '@services/cloud-signup-tracking.service';
-import { CloudService, CloudSignupRequest } from '@services/cloud.service';
+import { BillingInterval, CloudPlanCode, CloudService, CloudSignupRequest } from '@services/cloud.service';
 import { AUTH_FIELDSET_DESIGN_TOKENS, AUTH_SELECT_BUTTON_DESIGN_TOKENS } from '@core/theme/hitkeep-preset';
 
 type Jurisdiction = 'EU' | 'US';
@@ -37,7 +37,7 @@ export class Signup {
         EU: 'https://cloud.hitkeep.eu',
         US: 'https://cloud.hitkeep.com'
     };
-    private static readonly PRESERVED_QUERY_PARAMS = new Set(['ref', 'source', 'utm_source', 'utm_medium', 'utm_campaign', 'utm_term', 'utm_content', 'utm_id', 'utm_source_platform', 'utm_creative_format', 'utm_marketing_tactic']);
+    private static readonly PRESERVED_QUERY_PARAMS = new Set(['ref', 'source', 'plan', 'billing', 'utm_source', 'utm_medium', 'utm_campaign', 'utm_term', 'utm_content', 'utm_id', 'utm_source_platform', 'utm_creative_format', 'utm_marketing_tactic']);
 
     private readonly document = inject(DOCUMENT);
     private readonly destroyRef = inject(DestroyRef);
@@ -52,6 +52,8 @@ export class Signup {
     protected readonly cloudStatus = signal<CloudStatus | null>(null);
     protected readonly verificationSent = signal(false);
     protected readonly submittedEmail = signal('');
+    protected readonly selectedPlan = signal<CloudPlanCode>('free');
+    protected readonly selectedBilling = signal<BillingInterval>('monthly');
     private readonly activeLanguage = injectActiveLang();
     protected readonly currentYear = new Date().getFullYear();
     protected readonly jurisdictionOptions: Jurisdiction[] = ['EU', 'US'];
@@ -62,10 +64,22 @@ export class Signup {
     private trackedInitialSignupError = false;
 
     private readonly signupModel = signal({
-        email: new FormControl('', { nonNullable: true, validators: [Validators.required, Validators.email] }),
-        password: new FormControl('', { nonNullable: true, validators: [Validators.required, Validators.minLength(8)] }),
-        teamName: new FormControl('', { nonNullable: true, validators: [Validators.required, Validators.maxLength(120)] }),
-        acceptedTos: new FormControl(false, { nonNullable: true, validators: [Validators.requiredTrue] })
+        email: new FormControl('', {
+            nonNullable: true,
+            validators: [Validators.required, Validators.email]
+        }),
+        password: new FormControl('', {
+            nonNullable: true,
+            validators: [Validators.required, Validators.minLength(8)]
+        }),
+        teamName: new FormControl('', {
+            nonNullable: true,
+            validators: [Validators.required, Validators.maxLength(120)]
+        }),
+        acceptedTos: new FormControl(false, {
+            nonNullable: true,
+            validators: [Validators.requiredTrue]
+        })
     });
     protected readonly signupForm = compatForm(this.signupModel);
 
@@ -113,7 +127,8 @@ export class Signup {
             email: this.signupForm.email().value().trim().toLowerCase(),
             password: this.signupForm.password().value(),
             team_name: this.signupForm.teamName().value().trim(),
-            plan_code: 'free',
+            plan_code: this.selectedPlan(),
+            billing: this.selectedBilling(),
             jurisdiction: this.currentJurisdiction(),
             locale: this.activeLanguage(),
             accepted_tos: true
@@ -127,7 +142,9 @@ export class Signup {
             .pipe(finalize(() => this.isLoading.set(false)))
             .subscribe({
                 next: (response) => {
-                    this.trackSignupEvent('signup_completed_candidate', { response_status: response.status });
+                    this.trackSignupEvent('signup_completed_candidate', {
+                        response_status: response.status
+                    });
                     if (response.status === 'verification_sent') {
                         this.submittedEmail.set(payload.email);
                         this.verificationSent.set(true);
@@ -140,11 +157,17 @@ export class Signup {
                     console.error('Cloud signup failed', err);
                     if (err.status === 409) {
                         this.errorMessage.set('signup.errors.emailExists');
-                        this.trackSignupEvent('signup_error_view', { error_status: 409, error_code: 'email_exists' });
+                        this.trackSignupEvent('signup_error_view', {
+                            error_status: 409,
+                            error_code: 'email_exists'
+                        });
                         return;
                     }
                     this.errorMessage.set('signup.errors.unexpected');
-                    this.trackSignupEvent('signup_error_view', { error_status: err.status ?? 0, error_code: 'unexpected' });
+                    this.trackSignupEvent('signup_error_view', {
+                        error_status: err.status ?? 0,
+                        error_code: 'unexpected'
+                    });
                 }
             });
     }
@@ -166,11 +189,16 @@ export class Signup {
     }
 
     protected trackRegionSwitchClick(jurisdiction: Jurisdiction): void {
-        this.trackSignupEvent('cloud_region_switch_click', { target_jurisdiction: jurisdiction });
+        this.trackSignupEvent('cloud_region_switch_click', {
+            target_jurisdiction: jurisdiction
+        });
     }
 
     private hydrateFromQuery(): void {
         const params = this.route.snapshot.queryParamMap;
+
+        this.selectedPlan.set(this.normalizePlan(params.get('plan')));
+        this.selectedBilling.set(this.selectedPlan() === 'free' ? 'monthly' : this.normalizeBilling(params.get('billing')));
 
         const teamName = params.get('team_name')?.trim();
         if (teamName) {
@@ -236,13 +264,16 @@ export class Signup {
             return;
         }
         this.trackedInitialSignupError = true;
-        this.trackSignupEvent('signup_error_view', { error_code: 'verification_redirect' });
+        this.trackSignupEvent('signup_error_view', {
+            error_code: 'verification_redirect'
+        });
     }
 
     private trackSignupEvent(name: string, properties: Record<string, unknown> = {}): void {
         this.signupTracking.trackEvent(name, {
             jurisdiction: this.currentJurisdiction(),
-            plan_code: 'free',
+            plan: this.selectedPlan(),
+            interval: this.selectedBilling(),
             source_path: '/signup',
             ...properties
         });
@@ -262,5 +293,14 @@ export class Signup {
             return normalized;
         }
         return null;
+    }
+
+    private normalizePlan(value: string | null | undefined): CloudPlanCode {
+        const normalized = value?.trim().toLowerCase();
+        return normalized === 'pro' || normalized === 'business' ? normalized : 'free';
+    }
+
+    private normalizeBilling(value: string | null | undefined): BillingInterval {
+        return value?.trim().toLowerCase() === 'annual' ? 'annual' : 'monthly';
     }
 }

--- a/frontend/dashboard/src/app/pages/signup/verified-signup.spec.ts
+++ b/frontend/dashboard/src/app/pages/signup/verified-signup.spec.ts
@@ -1,0 +1,135 @@
+import { DOCUMENT } from '@angular/common';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { ActivatedRoute, Router, convertToParamMap } from '@angular/router';
+import { TranslocoTestingModule } from '@jsverse/transloco';
+import { Observable, of, throwError } from 'rxjs';
+import { vi } from 'vitest';
+
+import { VerifiedSignup } from '@pages/signup/verified-signup';
+import { CloudSignupTrackingService } from '@services/cloud-signup-tracking.service';
+import { BillingPortalSessionResponse, CloudService } from '@services/cloud.service';
+
+describe('VerifiedSignup', () => {
+    let queryParams: Record<string, string>;
+    let locationAssign: ReturnType<typeof vi.fn>;
+
+    const cloud = {
+        createBillingCheckoutSession: vi.fn<(request: unknown) => Observable<BillingPortalSessionResponse>>()
+    };
+    const tracking = {
+        install: vi.fn(),
+        trackEvent: vi.fn()
+    };
+    const router = {
+        navigateByUrl: vi.fn<(url: string) => Promise<boolean>>(() => Promise.resolve(true))
+    };
+
+    beforeEach(async () => {
+        vi.clearAllMocks();
+        queryParams = {};
+        locationAssign = vi.fn();
+        const location = {
+            hostname: 'cloud.hitkeep.eu',
+            assign: locationAssign
+        } as unknown as Location;
+        const defaultView = new Proxy(window, {
+            get(target, property) {
+                if (property === 'location') return location;
+                const value = Reflect.get(target, property, target);
+                return typeof value === 'function' ? value.bind(target) : value;
+            }
+        }) as Window;
+        const documentMock = new Proxy(document, {
+            get(target, property) {
+                if (property === 'defaultView') return defaultView;
+                const value = Reflect.get(target, property, target);
+                return typeof value === 'function' ? value.bind(target) : value;
+            }
+        }) as Document;
+
+        await TestBed.configureTestingModule({
+            imports: [
+                VerifiedSignup,
+                TranslocoTestingModule.forRoot({
+                    langs: { en: {} },
+                    translocoConfig: {
+                        availableLangs: ['en'],
+                        defaultLang: 'en'
+                    },
+                    preloadLangs: true
+                })
+            ],
+            providers: [
+                { provide: CloudService, useValue: cloud },
+                { provide: CloudSignupTrackingService, useValue: tracking },
+                { provide: Router, useValue: router },
+                { provide: DOCUMENT, useValue: documentMock },
+                {
+                    provide: ActivatedRoute,
+                    useValue: {
+                        snapshot: {
+                            get queryParamMap() {
+                                return convertToParamMap(queryParams);
+                            }
+                        }
+                    }
+                }
+            ]
+        })
+            .overrideComponent(VerifiedSignup, {
+                set: { imports: [], template: '<div></div>' }
+            })
+            .compileComponents();
+    });
+
+    function create(): ComponentFixture<VerifiedSignup> {
+        const fixture = TestBed.createComponent(VerifiedSignup);
+        fixture.detectChanges();
+        return fixture;
+    }
+
+    it('takes verified Business annual intent directly to checkout', () => {
+        queryParams = { plan: 'business', billing: 'annual' };
+        cloud.createBillingCheckoutSession.mockReturnValue(of({ url: 'https://checkout.stripe.com/c/pay/test' }));
+
+        create();
+
+        expect(cloud.createBillingCheckoutSession).toHaveBeenCalledWith({
+            plan_code: 'business',
+            billing: 'annual',
+            locale: 'en'
+        });
+        expect(tracking.trackEvent).toHaveBeenCalledWith('signup_verified', {
+            plan: 'business',
+            interval: 'annual',
+            jurisdiction: 'EU',
+            source_path: '/signup/verified'
+        });
+        expect(tracking.trackEvent).toHaveBeenCalledWith('checkout_started', {
+            plan: 'business',
+            interval: 'annual',
+            jurisdiction: 'EU',
+            source_path: '/signup/verified'
+        });
+        expect(locationAssign).toHaveBeenCalledWith('https://checkout.stripe.com/c/pay/test');
+    });
+
+    it('keeps a continue-on-Free escape hatch when checkout fails', () => {
+        queryParams = { plan: 'pro', billing: 'monthly' };
+        cloud.createBillingCheckoutSession.mockReturnValue(throwError(() => new Error('checkout unavailable')));
+
+        const fixture = create();
+        const component = fixture.componentInstance;
+        expect(component['checkoutFailed']()).toBe(true);
+
+        component['continueFree']();
+
+        expect(tracking.trackEvent).toHaveBeenCalledWith('continue_on_free', {
+            plan: 'pro',
+            interval: 'monthly',
+            jurisdiction: 'EU',
+            source_path: '/signup/verified'
+        });
+        expect(router.navigateByUrl).toHaveBeenCalledWith('/dashboard');
+    });
+});

--- a/frontend/dashboard/src/app/pages/signup/verified-signup.ts
+++ b/frontend/dashboard/src/app/pages/signup/verified-signup.ts
@@ -1,0 +1,134 @@
+import { DOCUMENT } from '@angular/common';
+import { ChangeDetectionStrategy, Component, DestroyRef, inject, signal } from '@angular/core';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
+import { ActivatedRoute, Router } from '@angular/router';
+import { TranslocoPipe } from '@jsverse/transloco';
+import { ButtonModule } from 'primeng/button';
+import { MessageModule } from 'primeng/message';
+
+import { Brand } from '@components/brand/brand';
+import { AuthCard } from '@core/components/auth-card/auth-card';
+import { injectActiveLang } from '@core/i18n/active-lang';
+import { BillingInterval, CloudService } from '@services/cloud.service';
+import { CloudSignupTrackingService } from '@services/cloud-signup-tracking.service';
+
+type PaidPlan = 'pro' | 'business';
+
+@Component({
+    selector: 'app-verified-signup',
+    imports: [AuthCard, Brand, ButtonModule, MessageModule, TranslocoPipe],
+    template: `
+        <main class="hk-auth-page">
+            <section class="hk-auth-shell" aria-labelledby="verified-signup-title">
+                <app-auth-card>
+                    <header class="hk-auth-header">
+                        <app-brand size="large" />
+                        <h1 id="verified-signup-title" class="hk-auth-title">
+                            {{ 'signup.verified.title' | transloco }}
+                        </h1>
+                        <p class="hk-auth-subtitle">
+                            {{
+                                'signup.verified.subtitle'
+                                    | transloco
+                                        : {
+                                              plan: 'signup.plans.' + plan() + '.name' | transloco,
+                                              billing: 'signup.billing.' + billing() | transloco
+                                          }
+                            }}
+                        </p>
+                    </header>
+
+                    <div class="hk-auth-form" aria-live="polite">
+                        @if (checkoutFailed()) {
+                            <p-message severity="error">{{ 'signup.verified.checkoutFailed' | transloco }}</p-message>
+                            <p-button [label]="'signup.verified.retryCheckout' | transloco" [loading]="checkoutPending()" [fluid]="true" (onClick)="startCheckout()" />
+                        } @else {
+                            <div class="flex items-center justify-center gap-3 rounded-lg border border-primary/20 bg-primary/5 px-4 py-4 text-sm">
+                                <i class="pi pi-spin pi-spinner text-primary" aria-hidden="true"></i>
+                                <span>{{ 'signup.verified.openingCheckout' | transloco }}</span>
+                            </div>
+                        }
+
+                        <p-button [label]="'signup.verified.continueFree' | transloco" severity="secondary" [text]="true" [fluid]="true" (onClick)="continueFree()" />
+                        <p class="m-0 text-center text-xs text-[var(--p-text-muted-color)]">
+                            {{ 'signup.verified.freeNote' | transloco }}
+                        </p>
+                    </div>
+                </app-auth-card>
+            </section>
+        </main>
+    `,
+    changeDetection: ChangeDetectionStrategy.OnPush
+})
+export class VerifiedSignup {
+    private readonly document = inject(DOCUMENT);
+    private readonly route = inject(ActivatedRoute);
+    private readonly router = inject(Router);
+    private readonly destroyRef = inject(DestroyRef);
+    private readonly cloud = inject(CloudService);
+    private readonly tracking = inject(CloudSignupTrackingService);
+    private readonly activeLanguage = injectActiveLang();
+
+    protected readonly plan = signal<PaidPlan>(this.normalizePlan(this.route.snapshot.queryParamMap.get('plan')));
+    protected readonly billing = signal<BillingInterval>(this.normalizeBilling(this.route.snapshot.queryParamMap.get('billing')));
+    protected readonly checkoutPending = signal(false);
+    protected readonly checkoutFailed = signal(false);
+
+    constructor() {
+        this.tracking.install();
+        this.track('signup_verified');
+        this.startCheckout();
+    }
+
+    protected startCheckout(): void {
+        if (this.checkoutPending()) {
+            return;
+        }
+        this.checkoutPending.set(true);
+        this.checkoutFailed.set(false);
+        this.cloud
+            .createBillingCheckoutSession({
+                plan_code: this.plan(),
+                billing: this.billing(),
+                locale: this.activeLanguage()
+            })
+            .pipe(takeUntilDestroyed(this.destroyRef))
+            .subscribe({
+                next: ({ url }) => {
+                    this.track('checkout_started');
+                    this.document.defaultView?.location.assign(url);
+                },
+                error: () => {
+                    this.checkoutPending.set(false);
+                    this.checkoutFailed.set(true);
+                }
+            });
+    }
+
+    protected continueFree(): void {
+        this.track('continue_on_free');
+        void this.router.navigateByUrl('/dashboard');
+    }
+
+    private track(name: string): void {
+        this.tracking.trackEvent(name, {
+            plan: this.plan(),
+            interval: this.billing(),
+            jurisdiction: this.inferJurisdiction(),
+            source_path: '/signup/verified'
+        });
+    }
+
+    private normalizePlan(value: string | null): PaidPlan {
+        return value?.trim().toLowerCase() === 'business' ? 'business' : 'pro';
+    }
+
+    private normalizeBilling(value: string | null): BillingInterval {
+        return value?.trim().toLowerCase() === 'annual' ? 'annual' : 'monthly';
+    }
+
+    private inferJurisdiction(): 'EU' | 'US' {
+        const hostname = this.document.defaultView?.location.hostname.toLowerCase() ?? '';
+        return hostname === 'cloud.hitkeep.com' || hostname.endsWith('.hitkeep.com') ? 'US' : 'EU';
+    }
+}

--- a/go.mod
+++ b/go.mod
@@ -26,7 +26,7 @@ require (
 	github.com/nsqio/nsq v1.3.0
 	github.com/pquerna/otp v1.5.0
 	github.com/rs/cors v1.11.1
-	github.com/stripe/stripe-go/v84 v84.4.1
+	github.com/stripe/stripe-go/v86 v86.1.0
 	github.com/wneessen/go-mail v0.8.0
 	github.com/zendev-sh/goai v0.8.6
 	golang.org/x/crypto v0.53.0

--- a/go.sum
+++ b/go.sum
@@ -389,8 +389,8 @@ github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UV
 github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81PSLYec5m4=
 github.com/stretchr/testify v1.11.1 h1:7s2iGBzp5EwR7/aIZr8ao5+dra3wiQyKjjFuvgVKu7U=
 github.com/stretchr/testify v1.11.1/go.mod h1:wZwfW3scLgRK+23gO65QZefKpKQRnfz6sD981Nm4B6U=
-github.com/stripe/stripe-go/v84 v84.4.1 h1:ixq1fG3y0k4OORVaN+LFAMBFaWiMrvKIcR9dSqT6gD8=
-github.com/stripe/stripe-go/v84 v84.4.1/go.mod h1:Z4gcKw1zl4geDG2+cjpSaJES9jaohGX6n7FP8/kHIqw=
+github.com/stripe/stripe-go/v86 v86.1.0 h1:xisqyg8BzooIEpaB74d8SD26d9JIPVQ1TkeB6t7gBKo=
+github.com/stripe/stripe-go/v86 v86.1.0/go.mod h1:Co7QRXCKGNOPTugAdvjgRo+KcMtd9hxy+pZMN0yThsQ=
 github.com/tdewolff/minify/v2 v2.24.2 h1:vnY3nTulEAbCAAlxTxPPDkzG24rsq31SOzp63yT+7mo=
 github.com/tdewolff/minify/v2 v2.24.2/go.mod h1:1JrCtoZXaDbqioQZfk3Jdmr0GPJKiU7c1Apmb+7tCeE=
 github.com/tdewolff/parse/v2 v2.8.3 h1:5VbvtJ83cfb289A1HzRA9sf02iT8YyUwN84ezjkdY1I=

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -136,6 +136,8 @@ type Config struct {
 	StripePortalConfigurationID string `env:"HITKEEP_STRIPE_PORTAL_CONFIGURATION_ID" default:""   desc:"Stripe customer portal configuration ID for managed cloud billing" cloud:"true"`
 	StripePriceProMonthly       string `env:"HITKEEP_STRIPE_PRICE_PRO_MONTHLY"       default:""      desc:"Stripe monthly recurring price ID for the Pro plan"               cloud:"true"`
 	StripePriceBusinessMonthly  string `env:"HITKEEP_STRIPE_PRICE_BUSINESS_MONTHLY" default:""     desc:"Stripe monthly recurring price ID for the Business plan"          cloud:"true"`
+	StripePriceProAnnual        string `env:"HITKEEP_STRIPE_PRICE_PRO_ANNUAL"        default:""      desc:"Stripe annual recurring price ID for the Pro plan"                cloud:"true"`
+	StripePriceBusinessAnnual   string `env:"HITKEEP_STRIPE_PRICE_BUSINESS_ANNUAL"   default:""      desc:"Stripe annual recurring price ID for the Business plan"           cloud:"true"`
 	CloudCheckoutSuccessURL     string `env:"HITKEEP_CLOUD_CHECKOUT_SUCCESS_URL"     default:""      desc:"Managed cloud checkout success URL override"                      cloud:"true"`
 	CloudCheckoutCancelURL      string `env:"HITKEEP_CLOUD_CHECKOUT_CANCEL_URL"      default:""      desc:"Managed cloud checkout cancel URL override"                       cloud:"true"`
 

--- a/internal/config/config_billing_test.go
+++ b/internal/config/config_billing_test.go
@@ -26,6 +26,8 @@ func TestLoadCloudConfigFromEnv(t *testing.T) {
 		"HITKEEP_STRIPE_PORTAL_CONFIGURATION_ID": "bpc_123",
 		"HITKEEP_STRIPE_PRICE_PRO_MONTHLY":       "price_pro",
 		"HITKEEP_STRIPE_PRICE_BUSINESS_MONTHLY":  "price_business",
+		"HITKEEP_STRIPE_PRICE_PRO_ANNUAL":        "price_pro_annual",
+		"HITKEEP_STRIPE_PRICE_BUSINESS_ANNUAL":   "price_business_annual",
 		"HITKEEP_CLOUD_CHECKOUT_SUCCESS_URL":     "https://cloud.hitkeep.eu/admin/team?checkout=success",
 		"HITKEEP_CLOUD_CHECKOUT_CANCEL_URL":      "https://cloud.hitkeep.eu/admin/team?checkout=cancelled",
 	}
@@ -55,7 +57,8 @@ func TestLoadCloudConfigFromEnv(t *testing.T) {
 	if conf.StripePortalConfigurationID != "bpc_123" {
 		t.Fatalf("unexpected stripe portal config: %+v", conf)
 	}
-	if conf.StripePriceProMonthly != "price_pro" || conf.StripePriceBusinessMonthly != "price_business" {
+	if conf.StripePriceProMonthly != "price_pro" || conf.StripePriceBusinessMonthly != "price_business" ||
+		conf.StripePriceProAnnual != "price_pro_annual" || conf.StripePriceBusinessAnnual != "price_business_annual" {
 		t.Fatalf("unexpected stripe price config: %+v", conf)
 	}
 }

--- a/internal/database/migrations/2026_07_14_010000_add_cloud_billing_intent.sql
+++ b/internal/database/migrations/2026_07_14_010000_add_cloud_billing_intent.sql
@@ -1,0 +1,8 @@
+ALTER TABLE pending_signups
+    ADD COLUMN plan_code VARCHAR DEFAULT 'free';
+
+ALTER TABLE pending_signups
+    ADD COLUMN billing_interval VARCHAR DEFAULT 'monthly';
+
+ALTER TABLE cloud_billing_accounts
+    ADD COLUMN billing_interval VARCHAR DEFAULT 'monthly';

--- a/internal/database/migrations/2026_07_14_020000_create_cloud_conversion_events.sql
+++ b/internal/database/migrations/2026_07_14_020000_create_cloud_conversion_events.sql
@@ -1,0 +1,16 @@
+CREATE TABLE IF NOT EXISTS cloud_conversion_events (
+    id UUID PRIMARY KEY,
+    tenant_id UUID NOT NULL REFERENCES tenants(id),
+    event_name VARCHAR NOT NULL,
+    plan_code VARCHAR NOT NULL,
+    billing_interval VARCHAR NOT NULL,
+    dedupe_key VARCHAR NOT NULL UNIQUE,
+    occurred_at TIMESTAMP NOT NULL,
+    created_at TIMESTAMP NOT NULL
+);
+
+CREATE INDEX IF NOT EXISTS idx_cloud_conversion_events_tenant_time
+    ON cloud_conversion_events(tenant_id, occurred_at);
+
+CREATE INDEX IF NOT EXISTS idx_cloud_conversion_events_name_time
+    ON cloud_conversion_events(event_name, occurred_at);

--- a/internal/database/runtime_cache.go
+++ b/internal/database/runtime_cache.go
@@ -37,6 +37,9 @@ const (
 
 	customTrackingDomainCacheSize = 4096
 	customTrackingDomainTTL       = 30 * time.Second
+
+	cloudConversionMilestoneCacheSize = 32768
+	cloudConversionMilestoneTTL       = 24 * time.Hour
 )
 
 type passwordResetEntry struct {
@@ -45,15 +48,17 @@ type passwordResetEntry struct {
 }
 
 type PendingSignupEntry struct {
-	Email          string
-	HashedPassword string
-	GivenName      string
-	LastName       string
-	TeamName       string
-	Jurisdiction   string
-	Locale         string
-	AcceptedTosAt  time.Time
-	ExpiresAt      time.Time
+	Email           string
+	HashedPassword  string
+	GivenName       string
+	LastName        string
+	TeamName        string
+	Jurisdiction    string
+	Locale          string
+	PlanCode        string
+	BillingInterval string
+	AcceptedTosAt   time.Time
+	ExpiresAt       time.Time
 }
 
 type apiClientAuthCacheEntry struct {
@@ -85,19 +90,22 @@ type runtimeCache struct {
 	// A nil value is a cached negative lookup.
 	customTrackingByHost *lru.LRU[string, *api.CustomTrackingDomain]
 	customTrackingSF     singleflight.Group
+
+	cloudConversionMilestones *lru.LRU[string, bool]
 }
 
 func newRuntimeCache() *runtimeCache {
 	return &runtimeCache{
-		passwordResetsByToken:   lru.NewLRU[string, passwordResetEntry](passwordResetCacheSize, nil, passwordResetTTL),
-		passwordResetTokenIndex: lru.NewLRU[string, string](passwordResetCacheSize, nil, passwordResetTTL),
-		apiClientAuthByToken:    lru.NewLRU[string, apiClientAuthCacheEntry](apiClientAuthCacheSize, nil, apiClientAuthTTL),
-		apiClientTokenByClient:  lru.NewLRU[uuid.UUID, string](apiClientAuthCacheSize, nil, apiClientAuthTTL),
-		instanceRoles:           lru.NewLRU[uuid.UUID, auth.InstanceRole](instanceRoleCacheSize, nil, instanceRoleTTL),
-		siteRoles:               lru.NewLRU[uuid.UUID, map[uuid.UUID]auth.SiteRole](siteRoleCacheSize, nil, siteRoleTTL),
-		siteTenantIDs:           lru.NewLRU[uuid.UUID, uuid.UUID](siteTenantCacheSize, nil, siteTenantTTL),
-		sitesByDomain:           lru.NewLRU[string, *api.Site](siteDomainCacheSize, nil, siteDomainTTL),
-		customTrackingByHost:    lru.NewLRU[string, *api.CustomTrackingDomain](customTrackingDomainCacheSize, nil, customTrackingDomainTTL),
+		passwordResetsByToken:     lru.NewLRU[string, passwordResetEntry](passwordResetCacheSize, nil, passwordResetTTL),
+		passwordResetTokenIndex:   lru.NewLRU[string, string](passwordResetCacheSize, nil, passwordResetTTL),
+		apiClientAuthByToken:      lru.NewLRU[string, apiClientAuthCacheEntry](apiClientAuthCacheSize, nil, apiClientAuthTTL),
+		apiClientTokenByClient:    lru.NewLRU[uuid.UUID, string](apiClientAuthCacheSize, nil, apiClientAuthTTL),
+		instanceRoles:             lru.NewLRU[uuid.UUID, auth.InstanceRole](instanceRoleCacheSize, nil, instanceRoleTTL),
+		siteRoles:                 lru.NewLRU[uuid.UUID, map[uuid.UUID]auth.SiteRole](siteRoleCacheSize, nil, siteRoleTTL),
+		siteTenantIDs:             lru.NewLRU[uuid.UUID, uuid.UUID](siteTenantCacheSize, nil, siteTenantTTL),
+		sitesByDomain:             lru.NewLRU[string, *api.Site](siteDomainCacheSize, nil, siteDomainTTL),
+		customTrackingByHost:      lru.NewLRU[string, *api.CustomTrackingDomain](customTrackingDomainCacheSize, nil, customTrackingDomainTTL),
+		cloudConversionMilestones: lru.NewLRU[string, bool](cloudConversionMilestoneCacheSize, nil, cloudConversionMilestoneTTL),
 	}
 }
 

--- a/internal/database/store_activity.go
+++ b/internal/database/store_activity.go
@@ -102,6 +102,17 @@ func (s *Store) RecordHitActivity(ctx context.Context, hits []*api.Hit) error {
 		if err := s.upsertSiteHitActivity(ctx, siteID, agg); err != nil {
 			return err
 		}
+		tenantID, err := s.GetSiteTenantID(ctx, siteID)
+		if err != nil {
+			return fmt.Errorf("resolve site tenant for first hit conversion: %w", err)
+		}
+		if _, err := s.RecordCloudConversionEvent(ctx, CloudConversionEvent{
+			TenantID:   tenantID,
+			EventName:  CloudConversionFirstHitReceived,
+			OccurredAt: agg.firstAt,
+		}); err != nil {
+			return fmt.Errorf("record first hit conversion: %w", err)
+		}
 	}
 	if err := s.flushSiteActivityCounts(ctx, counts, true); err != nil {
 		return err

--- a/internal/database/store_analytics.go
+++ b/internal/database/store_analytics.go
@@ -397,29 +397,13 @@ func (s *Store) GetSiteStats(ctx context.Context, params api.AnalyticsParams) (*
 	}
 
 	for _, goal := range goals {
-		var conversions int
-		var err error
-
-		switch goal.Type {
-		case "path":
-			err = s.db.QueryRowContext(ctx, `
-				SELECT COUNT(DISTINCT session_id)
-				FROM hits
-				WHERE site_id = ? AND timestamp >= ? AND timestamp <= ? AND path = ?
-			`, params.SiteID, params.Start, params.End, goal.Value).Scan(&conversions)
-		case "event":
-			err = s.db.QueryRowContext(ctx, `
-				SELECT COUNT(DISTINCT session_id)
-				FROM events
-				WHERE site_id = ? AND timestamp >= ? AND timestamp <= ? AND name = ?
-			`, params.SiteID, params.Start, params.End, goal.Value).Scan(&conversions)
-			if err == nil && canIncludeImportedSiteAggregates(params, truncUnit) {
-				importedConversions, importErr := s.queryImportedEventGoalConversions(ctx, params, goal.Value)
-				if importErr != nil {
-					return nil, importErr
-				}
-				conversions += importedConversions
+		conversions, err := s.queryGoalConversions(ctx, params, goal, filterSQL, filterArgs)
+		if goal.Type == "event" && err == nil && canIncludeImportedSiteAggregates(params, truncUnit) {
+			importedConversions, importErr := s.queryImportedEventGoalConversions(ctx, params, goal.Value)
+			if importErr != nil {
+				return nil, importErr
 			}
+			conversions += importedConversions
 		}
 
 		if err != nil {

--- a/internal/database/store_analytics_comparison_test.go
+++ b/internal/database/store_analytics_comparison_test.go
@@ -117,6 +117,64 @@ func TestGetSiteStatsNoComparison(t *testing.T) {
 	}
 }
 
+func TestGetSiteStatsFiltersGoalConversionsToMatchingSessionCohort(t *testing.T) {
+	store, userID := setupComparisonStore(t)
+	ctx := context.Background()
+
+	site, err := store.CreateSite(ctx, userID, "filtered-goals.example.com")
+	if err != nil {
+		t.Fatalf("create site: %v", err)
+	}
+	if err := store.CreateGoal(ctx, &api.Goal{
+		SiteID: site.ID,
+		Name:   "Reached signup",
+		Type:   "path",
+		Value:  "/signup",
+	}); err != nil {
+		t.Fatalf("create goal: %v", err)
+	}
+
+	now := time.Now().UTC()
+	matchingSession := uuid.New()
+	unmatchedSession := uuid.New()
+	for _, hit := range []api.Hit{
+		{SiteID: site.ID, SessionID: matchingSession, PageID: uuid.New(), Timestamp: now.Add(-4 * time.Hour), Path: "/pricing"},
+		{SiteID: site.ID, SessionID: matchingSession, PageID: uuid.New(), Timestamp: now.Add(-3 * time.Hour), Path: "/signup"},
+		{SiteID: site.ID, SessionID: unmatchedSession, PageID: uuid.New(), Timestamp: now.Add(-2 * time.Hour), Path: "/blog"},
+		{SiteID: site.ID, SessionID: unmatchedSession, PageID: uuid.New(), Timestamp: now.Add(-time.Hour), Path: "/signup"},
+	} {
+		hit := hit
+		if err := store.CreateHit(ctx, &hit); err != nil {
+			t.Fatalf("create hit %s: %v", hit.Path, err)
+		}
+	}
+
+	stats, err := store.GetSiteStats(ctx, api.AnalyticsParams{
+		SiteID: site.ID,
+		UserID: userID,
+		Start:  now.Add(-24 * time.Hour),
+		End:    now,
+		Filters: []api.Filter{
+			{Type: "path", Value: "/pricing"},
+		},
+	})
+	if err != nil {
+		t.Fatalf("GetSiteStats: %v", err)
+	}
+	if stats.UniqueSessions != 1 {
+		t.Fatalf("expected one session in the filtered cohort, got %d", stats.UniqueSessions)
+	}
+	if len(stats.Goals) != 1 {
+		t.Fatalf("expected one goal, got %+v", stats.Goals)
+	}
+	if stats.Goals[0].Conversions != 1 {
+		t.Fatalf("expected one conversion from the filtered session cohort, got %+v", stats.Goals[0])
+	}
+	if stats.Goals[0].ConversionRate != 100 {
+		t.Fatalf("expected a 100%% conversion rate, got %+v", stats.Goals[0])
+	}
+}
+
 func TestGetSiteStatsComparisonCurrentPeriodEmpty(t *testing.T) {
 	store, userID := setupComparisonStore(t)
 	ctx := context.Background()

--- a/internal/database/store_analytics_goals.go
+++ b/internal/database/store_analytics_goals.go
@@ -417,10 +417,13 @@ func (s *Store) GetFunnelStats(ctx context.Context, funnelID uuid.UUID, params a
 // so any arbitrary window is supported.
 func (s *Store) GetComparisonStats(ctx context.Context, params api.AnalyticsParams) (*api.ComparisonStats, error) {
 	cmp := api.AnalyticsParams{
-		SiteID: params.SiteID,
-		UserID: params.UserID,
-		Start:  params.CompareStart,
-		End:    params.CompareEnd,
+		SiteID:    params.SiteID,
+		UserID:    params.UserID,
+		Start:     params.CompareStart,
+		End:       params.CompareEnd,
+		Filters:   params.Filters,
+		GoalIDs:   params.GoalIDs,
+		FunnelIDs: params.FunnelIDs,
 	}
 
 	stats := &api.ComparisonStats{
@@ -430,20 +433,33 @@ func (s *Store) GetComparisonStats(ctx context.Context, params api.AnalyticsPara
 	truncUnit := truncUnitForRange(cmp.Start, cmp.End)
 	gridStart := truncToUnit(cmp.Start, truncUnit)
 	gridEnd := truncToUnit(cmp.End, truncUnit)
+	filterSQL, filterArgs := buildHitFilters(cmp.Filters, "h")
+	funnelPathSQL, funnelPathArgs, err := s.buildFunnelPathFilter(ctx, cmp, "h")
+	if err != nil {
+		return nil, err
+	}
+	sessionSQL, sessionArgs, err := s.buildSessionFilter(ctx, cmp, "h")
+	if err != nil {
+		return nil, err
+	}
+	filterSQL += funnelPathSQL
+	filterSQL += sessionSQL
+	filterArgs = append(filterArgs, funnelPathArgs...)
+	filterArgs = append(filterArgs, sessionArgs...)
 
-	if err := s.queryKpis(ctx, cmp, "", nil, false, rollupHourly,
+	if err := s.queryKpis(ctx, cmp, filterSQL, filterArgs, false, rollupHourly,
 		&stats.TotalPageviews, &stats.UniqueSessions, &stats.BounceRate, &stats.AvgSessionDuration, &stats.PagesPerSession,
 	); err != nil {
 		return nil, fmt.Errorf("comparison KPI query failed: %w", err)
 	}
 
-	if err := s.queryUTMKpis(ctx, cmp, "", nil,
+	if err := s.queryUTMKpis(ctx, cmp, filterSQL, filterArgs,
 		&stats.UTMCampaignHits, &stats.UTMContentHits, &stats.UTMMediumHits, &stats.UTMSourceHits, &stats.UTMTermHits,
 	); err != nil {
 		return nil, fmt.Errorf("comparison UTM KPI query failed: %w", err)
 	}
 
-	rows, err := s.queryChartData(ctx, cmp, gridStart, gridEnd, truncUnit, "", nil, false, rollupHourly)
+	rows, err := s.queryChartData(ctx, cmp, gridStart, gridEnd, truncUnit, filterSQL, filterArgs, false, rollupHourly)
 	if err != nil {
 		return nil, fmt.Errorf("comparison chart query failed: %w", err)
 	}
@@ -466,24 +482,7 @@ func (s *Store) GetComparisonStats(ctx context.Context, params api.AnalyticsPara
 	}
 
 	for _, goal := range goals {
-		var conversions int
-		var err error
-
-		switch goal.Type {
-		case "path":
-			err = s.db.QueryRowContext(ctx, `
-				SELECT COUNT(DISTINCT session_id)
-				FROM hits
-				WHERE site_id = ? AND timestamp >= ? AND timestamp <= ? AND path = ?
-			`, cmp.SiteID, cmp.Start, cmp.End, goal.Value).Scan(&conversions)
-		case "event":
-			err = s.db.QueryRowContext(ctx, `
-				SELECT COUNT(DISTINCT session_id)
-				FROM events
-				WHERE site_id = ? AND timestamp >= ? AND timestamp <= ? AND name = ?
-			`, cmp.SiteID, cmp.Start, cmp.End, goal.Value).Scan(&conversions)
-		}
-
+		conversions, err := s.queryGoalConversions(ctx, cmp, goal, filterSQL, filterArgs)
 		if err != nil {
 			return nil, fmt.Errorf("comparison goal conversions query failed: %w", err)
 		}
@@ -503,6 +502,59 @@ func (s *Store) GetComparisonStats(ctx context.Context, params api.AnalyticsPara
 	}
 
 	return stats, nil
+}
+
+func (s *Store) queryGoalConversions(
+	ctx context.Context,
+	params api.AnalyticsParams,
+	goal api.Goal,
+	filterSQL string,
+	filterArgs []any,
+) (int, error) {
+	var goalTable string
+	var goalColumn string
+	switch goal.Type {
+	case "path":
+		goalTable = "hits"
+		goalColumn = "path"
+	case "event":
+		goalTable = "events"
+		goalColumn = "name"
+	default:
+		return 0, nil
+	}
+
+	// Goal conversions belong to the report's session cohort. Applying a page
+	// filter directly to the goal row would incorrectly require the goal page to
+	// be the filtered page, so the filtered hits are selected as a cohort first.
+	//nolint:gosec // table/column are fixed above and filterSQL comes from allowlisted filters
+	query := fmt.Sprintf(`
+		SELECT COUNT(DISTINCT g.session_id)
+		FROM %s g
+		WHERE g.site_id = ?
+			AND g.timestamp >= ?
+			AND g.timestamp <= ?
+			AND g.%s = ?
+	`, goalTable, goalColumn)
+	args := []any{params.SiteID, params.Start, params.End, goal.Value}
+	if filterSQL != "" {
+		//nolint:gosec // filterSQL comes from allowlisted analytics filters
+		query += fmt.Sprintf(`
+			AND g.session_id IN (
+				SELECT DISTINCT h.session_id
+				FROM hits h
+				WHERE h.site_id = ? AND h.timestamp >= ? AND h.timestamp <= ?%s
+			)
+		`, filterSQL)
+		args = append(args, params.SiteID, params.Start, params.End)
+		args = append(args, filterArgs...)
+	}
+
+	var conversions int
+	if err := s.db.QueryRowContext(ctx, query, args...).Scan(&conversions); err != nil {
+		return 0, err
+	}
+	return conversions, nil
 }
 
 func (s *Store) queryFunnelStepSessions(ctx context.Context, params api.AnalyticsParams, step api.FunnelStep) (map[uuid.UUID]bool, error) {

--- a/internal/database/store_cloud_billing_billing.go
+++ b/internal/database/store_cloud_billing_billing.go
@@ -17,6 +17,8 @@ const (
 	CloudPlanFree                            = "free"
 	CloudPlanPro                             = "pro"
 	CloudPlanBusiness                        = "business"
+	CloudBillingIntervalMonthly              = "monthly"
+	CloudBillingIntervalAnnual               = "annual"
 	CloudFreePlanSiteLimit                   = 3
 	CloudFreePlanMemberLimit                 = 3
 	CloudSubscriptionStatusFree              = "free"
@@ -92,6 +94,7 @@ type CloudBillingAccount struct {
 	TenantID             uuid.UUID
 	PlanCode             string
 	PlanName             string
+	BillingInterval      string
 	SubscriptionStatus   string
 	StripeCustomerID     string
 	StripeSubscriptionID string
@@ -180,6 +183,7 @@ func (s *Store) CreateManagedCloudAccount(ctx context.Context, input CreateManag
 
 func (s *Store) UpsertCloudBillingAccount(ctx context.Context, account CloudBillingAccount) error {
 	now := time.Now().UTC()
+	account.BillingInterval = normalizeCloudBillingInterval(account.BillingInterval)
 	if account.CreatedAt.IsZero() {
 		account.CreatedAt = now
 	}
@@ -189,18 +193,20 @@ func (s *Store) UpsertCloudBillingAccount(ctx context.Context, account CloudBill
 		INSERT INTO cloud_billing_accounts (
 			tenant_id,
 			plan_code,
-			plan_name,
-			subscription_status,
+				plan_name,
+				billing_interval,
+				subscription_status,
 			stripe_customer_id,
 			stripe_subscription_id,
 			stripe_price_id,
 			created_at,
 			updated_at
 		)
-		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
-		ON CONFLICT (tenant_id) DO UPDATE SET
-			plan_code = excluded.plan_code,
-			plan_name = excluded.plan_name,
+			VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+			ON CONFLICT (tenant_id) DO UPDATE SET
+				plan_code = excluded.plan_code,
+				plan_name = excluded.plan_name,
+				billing_interval = excluded.billing_interval,
 			subscription_status = excluded.subscription_status,
 			stripe_customer_id = excluded.stripe_customer_id,
 			stripe_subscription_id = excluded.stripe_subscription_id,
@@ -210,6 +216,7 @@ func (s *Store) UpsertCloudBillingAccount(ctx context.Context, account CloudBill
 		account.TenantID,
 		account.PlanCode,
 		account.PlanName,
+		account.BillingInterval,
 		account.SubscriptionStatus,
 		nullIfBlank(account.StripeCustomerID),
 		nullIfBlank(account.StripeSubscriptionID),
@@ -219,6 +226,13 @@ func (s *Store) UpsertCloudBillingAccount(ctx context.Context, account CloudBill
 	)
 }
 
+func normalizeCloudBillingInterval(interval string) string {
+	if strings.EqualFold(strings.TrimSpace(interval), CloudBillingIntervalAnnual) {
+		return CloudBillingIntervalAnnual
+	}
+	return CloudBillingIntervalMonthly
+}
+
 func (s *Store) GetCloudBillingAccount(ctx context.Context, tenantID uuid.UUID) (*CloudBillingAccount, error) {
 	var account CloudBillingAccount
 	var customerID sql.NullString
@@ -226,7 +240,7 @@ func (s *Store) GetCloudBillingAccount(ctx context.Context, tenantID uuid.UUID) 
 	var priceID sql.NullString
 
 	err := s.db.QueryRowContext(ctx, `
-		SELECT tenant_id, plan_code, plan_name, subscription_status,
+			SELECT tenant_id, plan_code, plan_name, billing_interval, subscription_status,
 		       COALESCE(stripe_customer_id, ''), COALESCE(stripe_subscription_id, ''), COALESCE(stripe_price_id, ''),
 		       created_at, updated_at
 		FROM cloud_billing_accounts
@@ -235,6 +249,7 @@ func (s *Store) GetCloudBillingAccount(ctx context.Context, tenantID uuid.UUID) 
 		&account.TenantID,
 		&account.PlanCode,
 		&account.PlanName,
+		&account.BillingInterval,
 		&account.SubscriptionStatus,
 		&customerID,
 		&subscriptionID,
@@ -430,7 +445,7 @@ func (s *Store) getCloudBillingAccountByField(ctx context.Context, field string,
 
 	// #nosec G201 -- queryField is restricted to the column whitelist in the switch above.
 	query := fmt.Sprintf(`
-		SELECT tenant_id, plan_code, plan_name, subscription_status,
+			SELECT tenant_id, plan_code, plan_name, billing_interval, subscription_status,
 		       COALESCE(stripe_customer_id, ''), COALESCE(stripe_subscription_id, ''), COALESCE(stripe_price_id, ''),
 		       created_at, updated_at
 		FROM cloud_billing_accounts
@@ -441,6 +456,7 @@ func (s *Store) getCloudBillingAccountByField(ctx context.Context, field string,
 		&account.TenantID,
 		&account.PlanCode,
 		&account.PlanName,
+		&account.BillingInterval,
 		&account.SubscriptionStatus,
 		&customerID,
 		&subscriptionID,

--- a/internal/database/store_cloud_billing_billing_test.go
+++ b/internal/database/store_cloud_billing_billing_test.go
@@ -104,6 +104,66 @@ func TestUpsertCloudBillingAccountRoundTrips(t *testing.T) {
 	}
 }
 
+func TestRecordCloudConversionEventsPreservesIntentAndDeduplicatesMilestones(t *testing.T) {
+	store := NewStore(":memory:")
+	if err := store.Connect(); err != nil {
+		t.Fatalf("connect store: %v", err)
+	}
+	defer store.Close()
+	if err := store.Migrate(context.Background()); err != nil {
+		t.Fatalf("migrate store: %v", err)
+	}
+
+	account, err := store.CreateManagedCloudAccount(context.Background(), CreateManagedCloudAccountInput{
+		Email:          "conversion-owner@example.com",
+		HashedPassword: "hashed",
+		TeamName:       "Conversion Team",
+	})
+	if err != nil {
+		t.Fatalf("create managed cloud account: %v", err)
+	}
+	if err := store.UpsertCloudBillingAccount(context.Background(), CloudBillingAccount{
+		TenantID:           account.TenantID,
+		PlanCode:           CloudPlanFree,
+		PlanName:           "Free",
+		BillingInterval:    CloudBillingIntervalAnnual,
+		SubscriptionStatus: CloudSubscriptionStatusFree,
+	}); err != nil {
+		t.Fatalf("upsert billing account: %v", err)
+	}
+
+	inserted, err := store.RecordCloudConversionEvent(context.Background(), CloudConversionEvent{
+		TenantID:        account.TenantID,
+		EventName:       CloudConversionSignupVerified,
+		PlanCode:        CloudPlanPro,
+		BillingInterval: CloudBillingIntervalAnnual,
+	})
+	if err != nil || !inserted {
+		t.Fatalf("record signup conversion: inserted=%v err=%v", inserted, err)
+	}
+	inserted, err = store.RecordCloudConversionEvent(context.Background(), CloudConversionEvent{
+		TenantID:  account.TenantID,
+		EventName: CloudConversionSignupVerified,
+	})
+	if err != nil {
+		t.Fatalf("repeat signup conversion: %v", err)
+	}
+	if inserted {
+		t.Fatal("expected repeated one-time milestone to be deduplicated")
+	}
+
+	events, err := store.ListCloudConversionEvents(context.Background(), account.TenantID)
+	if err != nil {
+		t.Fatalf("list conversion events: %v", err)
+	}
+	if len(events) != 1 {
+		t.Fatalf("expected one conversion event, got %d", len(events))
+	}
+	if events[0].PlanCode != CloudPlanPro || events[0].BillingInterval != CloudBillingIntervalAnnual {
+		t.Fatalf("expected pro annual intent, got %+v", events[0])
+	}
+}
+
 func TestCloudBillingEventsAreIdempotentAndTrackStatus(t *testing.T) {
 	store := NewStore(":memory:")
 	if err := store.Connect(); err != nil {

--- a/internal/database/store_cloud_conversion.go
+++ b/internal/database/store_cloud_conversion.go
@@ -1,0 +1,161 @@
+package database
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/google/uuid"
+)
+
+const (
+	CloudConversionSignupVerified        = "signup_verified"
+	CloudConversionFirstSiteCreated      = "first_site_created"
+	CloudConversionFirstHitReceived      = "first_hit_received"
+	CloudConversionCheckoutStarted       = "checkout_started"
+	CloudConversionSubscriptionActivated = "subscription_activated"
+)
+
+var cloudConversionEventNames = map[string]struct{}{
+	CloudConversionSignupVerified:        {},
+	CloudConversionFirstSiteCreated:      {},
+	CloudConversionFirstHitReceived:      {},
+	CloudConversionCheckoutStarted:       {},
+	CloudConversionSubscriptionActivated: {},
+}
+
+type CloudConversionEvent struct {
+	ID              uuid.UUID
+	TenantID        uuid.UUID
+	EventName       string
+	PlanCode        string
+	BillingInterval string
+	DedupeKey       string
+	OccurredAt      time.Time
+	CreatedAt       time.Time
+}
+
+// RecordCloudConversionEvent records a privacy-safe product milestone. Blank
+// plan and interval values inherit the tenant's current billing account. A
+// blank dedupe key makes the milestone one-time per tenant.
+func (s *Store) RecordCloudConversionEvent(ctx context.Context, event CloudConversionEvent) (bool, error) {
+	event.EventName = strings.TrimSpace(strings.ToLower(event.EventName))
+	if _, ok := cloudConversionEventNames[event.EventName]; !ok {
+		return false, fmt.Errorf("unsupported cloud conversion event %q", event.EventName)
+	}
+	if event.TenantID == uuid.Nil {
+		return false, fmt.Errorf("cloud conversion tenant id is required")
+	}
+	if strings.TrimSpace(event.DedupeKey) == "" {
+		event.DedupeKey = event.TenantID.String() + ":" + event.EventName
+		if s.runtime != nil && s.runtime.cloudConversionMilestones != nil {
+			if _, ok := s.runtime.cloudConversionMilestones.Get(event.DedupeKey); ok {
+				return false, nil
+			}
+		}
+	} else {
+		event.DedupeKey = strings.TrimSpace(event.DedupeKey)
+	}
+
+	var accountPlan, accountInterval string
+	err := s.db.QueryRowContext(ctx, `
+		SELECT COALESCE(plan_code, ''), COALESCE(billing_interval, '')
+		FROM cloud_billing_accounts
+		WHERE tenant_id = ?
+	`, event.TenantID).Scan(&accountPlan, &accountInterval)
+	if err == sql.ErrNoRows {
+		if s.runtime != nil && s.runtime.cloudConversionMilestones != nil {
+			s.runtime.cloudConversionMilestones.Add(event.DedupeKey, false)
+		}
+		return false, nil
+	}
+	if err != nil {
+		return false, fmt.Errorf("resolve cloud conversion billing context: %w", err)
+	}
+
+	event.PlanCode = normalizeCloudConversionPlan(event.PlanCode, accountPlan)
+	event.BillingInterval = normalizeCloudConversionInterval(event.BillingInterval, accountInterval)
+	if event.ID == uuid.Nil {
+		event.ID = uuid.New()
+	}
+	if event.OccurredAt.IsZero() {
+		event.OccurredAt = time.Now().UTC()
+	}
+	if event.CreatedAt.IsZero() {
+		event.CreatedAt = time.Now().UTC()
+	}
+
+	result, err := s.db.ExecContext(ctx, `
+		INSERT INTO cloud_conversion_events (
+			id, tenant_id, event_name, plan_code, billing_interval,
+			dedupe_key, occurred_at, created_at
+		)
+		VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+		ON CONFLICT (dedupe_key) DO NOTHING
+	`, event.ID, event.TenantID, event.EventName, event.PlanCode, event.BillingInterval, event.DedupeKey, event.OccurredAt.UTC(), event.CreatedAt.UTC())
+	if err != nil {
+		return false, fmt.Errorf("record cloud conversion event: %w", err)
+	}
+	rows, err := result.RowsAffected()
+	if err != nil {
+		return false, fmt.Errorf("read cloud conversion insert result: %w", err)
+	}
+	if s.runtime != nil && s.runtime.cloudConversionMilestones != nil {
+		s.runtime.cloudConversionMilestones.Add(event.DedupeKey, true)
+	}
+	return rows > 0, nil
+}
+
+func (s *Store) ListCloudConversionEvents(ctx context.Context, tenantID uuid.UUID) ([]CloudConversionEvent, error) {
+	rows, err := s.db.QueryContext(ctx, `
+		SELECT id, tenant_id, event_name, plan_code, billing_interval, dedupe_key, occurred_at, created_at
+		FROM cloud_conversion_events
+		WHERE tenant_id = ?
+		ORDER BY occurred_at ASC, event_name ASC
+	`, tenantID)
+	if err != nil {
+		return nil, fmt.Errorf("list cloud conversion events: %w", err)
+	}
+	defer rows.Close()
+
+	events := make([]CloudConversionEvent, 0)
+	for rows.Next() {
+		var event CloudConversionEvent
+		if err := rows.Scan(&event.ID, &event.TenantID, &event.EventName, &event.PlanCode, &event.BillingInterval, &event.DedupeKey, &event.OccurredAt, &event.CreatedAt); err != nil {
+			return nil, fmt.Errorf("scan cloud conversion event: %w", err)
+		}
+		events = append(events, event)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("iterate cloud conversion events: %w", err)
+	}
+	return events, nil
+}
+
+func normalizeCloudConversionPlan(requested, fallback string) string {
+	for _, value := range []string{requested, fallback} {
+		switch strings.TrimSpace(strings.ToLower(value)) {
+		case "pro":
+			return "pro"
+		case "business":
+			return "business"
+		case "free":
+			return "free"
+		}
+	}
+	return "free"
+}
+
+func normalizeCloudConversionInterval(requested, fallback string) string {
+	for _, value := range []string{requested, fallback} {
+		switch strings.TrimSpace(strings.ToLower(value)) {
+		case "annual":
+			return "annual"
+		case "monthly":
+			return "monthly"
+		}
+	}
+	return "monthly"
+}

--- a/internal/database/store_cloud_signup.go
+++ b/internal/database/store_cloud_signup.go
@@ -27,6 +27,11 @@ func (s *Store) CreatePendingSignup(ctx context.Context, entry PendingSignupEntr
 	}
 	token := hex.EncodeToString(bytes)
 	entry.ExpiresAt = time.Now().UTC().Add(pendingSignupTTL)
+	entry.PlanCode = strings.TrimSpace(strings.ToLower(entry.PlanCode))
+	if entry.PlanCode == "" {
+		entry.PlanCode = CloudPlanFree
+	}
+	entry.BillingInterval = normalizeCloudBillingInterval(entry.BillingInterval)
 
 	// Remove any existing pending signup for this email.
 	normalizedEmail := strings.TrimSpace(strings.ToLower(entry.Email))
@@ -38,10 +43,11 @@ func (s *Store) CreatePendingSignup(ctx context.Context, entry PendingSignupEntr
 	}
 
 	if _, err := s.db.ExecContext(ctx, `
-		INSERT INTO pending_signups (token, email, hashed_password, given_name, last_name, team_name, jurisdiction, locale, accepted_tos_at, expires_at)
-		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+		INSERT INTO pending_signups (token, email, hashed_password, given_name, last_name, team_name, jurisdiction, locale, plan_code, billing_interval, accepted_tos_at, expires_at)
+		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
 		token, entry.Email, entry.HashedPassword, entry.GivenName, entry.LastName,
-		entry.TeamName, entry.Jurisdiction, entry.Locale, sql.NullTime{Time: entry.AcceptedTosAt, Valid: !entry.AcceptedTosAt.IsZero()}, entry.ExpiresAt,
+		entry.TeamName, entry.Jurisdiction, entry.Locale, entry.PlanCode, entry.BillingInterval,
+		sql.NullTime{Time: entry.AcceptedTosAt, Valid: !entry.AcceptedTosAt.IsZero()}, entry.ExpiresAt,
 	); err != nil {
 		return "", fmt.Errorf("insert pending signup: %w", err)
 	}
@@ -58,10 +64,10 @@ func (s *Store) CompletePendingSignup(ctx context.Context, token string) (*Pendi
 	var entry PendingSignupEntry
 	var acceptedTosAt sql.NullTime
 	err := s.db.QueryRowContext(ctx, `
-		SELECT email, hashed_password, given_name, last_name, team_name, jurisdiction, locale, accepted_tos_at, expires_at
+		SELECT email, hashed_password, given_name, last_name, team_name, jurisdiction, locale, plan_code, billing_interval, accepted_tos_at, expires_at
 		FROM pending_signups WHERE token = ?`, token,
 	).Scan(&entry.Email, &entry.HashedPassword, &entry.GivenName, &entry.LastName,
-		&entry.TeamName, &entry.Jurisdiction, &entry.Locale, &acceptedTosAt, &entry.ExpiresAt)
+		&entry.TeamName, &entry.Jurisdiction, &entry.Locale, &entry.PlanCode, &entry.BillingInterval, &acceptedTosAt, &entry.ExpiresAt)
 	if errors.Is(err, sql.ErrNoRows) {
 		return nil, ErrPendingSignupInvalid
 	}

--- a/internal/server/cloud/handlers_billing.go
+++ b/internal/server/cloud/handlers_billing.go
@@ -8,11 +8,12 @@ import (
 	"errors"
 	"log/slog"
 	"net/http"
+	"net/url"
 	"strings"
 	"time"
 
 	"github.com/google/uuid"
-	stripe "github.com/stripe/stripe-go/v84"
+	stripe "github.com/stripe/stripe-go/v86"
 
 	"hitkeep/internal/api"
 	"hitkeep/internal/appurl"
@@ -29,7 +30,7 @@ const (
 	subscriptionStatusActive   = database.CloudSubscriptionStatusActive
 	subscriptionStatusPending  = database.CloudSubscriptionStatusPendingCheckout
 	subscriptionStatusCanceled = database.CloudSubscriptionStatusCanceled
-	stripeAPIVersion           = "2026-02-25.clover"
+	stripeAPIVersion           = "2026-06-24.dahlia"
 )
 
 type stripeClient interface {
@@ -50,27 +51,28 @@ type handler struct {
 }
 
 type createCustomerInput struct {
-	Email          string
-	Name           string
-	UserID         uuid.UUID
-	TenantID       uuid.UUID
-	PlanCode       string
-	Jurisdiction   string
-	IdempotencyKey string
+	Email           string
+	Name            string
+	UserID          uuid.UUID
+	TenantID        uuid.UUID
+	PlanCode        string
+	BillingInterval string
+	Jurisdiction    string
+	IdempotencyKey  string
 }
 
 type createCheckoutSessionInput struct {
-	CustomerID   string
-	PriceID      string
-	SuccessURL   string
-	CancelURL    string
-	Locale       string
-	UserID       uuid.UUID
-	TenantID     uuid.UUID
-	PlanCode     string
-	PlanName     string
-	Jurisdiction string
-	Email        string
+	CustomerID      string
+	PriceID         string
+	SuccessURL      string
+	CancelURL       string
+	Locale          string
+	UserID          uuid.UUID
+	TenantID        uuid.UUID
+	PlanCode        string
+	PlanName        string
+	BillingInterval string
+	Jurisdiction    string
 }
 
 type checkoutSessionOutput struct {
@@ -133,22 +135,24 @@ func Register(mux *http.ServeMux, ctx *shared.Context) {
 }
 
 type signupRequest struct {
-	Email        string `json:"email"`
-	Password     string `json:"password"`
-	GivenName    string `json:"given_name"`
-	LastName     string `json:"last_name"`
-	TeamName     string `json:"team_name"`
-	PlanCode     string `json:"plan_code"`
-	Jurisdiction string `json:"jurisdiction"`
-	Locale       string `json:"locale"`
-	AcceptedTos  bool   `json:"accepted_tos"`
+	Email           string `json:"email"`
+	Password        string `json:"password"`
+	GivenName       string `json:"given_name"`
+	LastName        string `json:"last_name"`
+	TeamName        string `json:"team_name"`
+	PlanCode        string `json:"plan_code"`
+	BillingInterval string `json:"billing"`
+	Jurisdiction    string `json:"jurisdiction"`
+	Locale          string `json:"locale"`
+	AcceptedTos     bool   `json:"accepted_tos"`
 }
 
 type signupResponse struct {
-	Status      string `json:"status"`
-	PlanCode    string `json:"plan_code"`
-	RedirectURL string `json:"redirect_url,omitempty"`
-	CheckoutURL string `json:"checkout_url,omitempty"`
+	Status          string `json:"status"`
+	PlanCode        string `json:"plan_code"`
+	BillingInterval string `json:"billing"`
+	RedirectURL     string `json:"redirect_url,omitempty"`
+	CheckoutURL     string `json:"checkout_url,omitempty"`
 }
 
 type billingPortalSessionResponse struct {
@@ -160,8 +164,9 @@ type billingPortalSessionRequest struct {
 }
 
 type billingCheckoutSessionRequest struct {
-	PlanCode string `json:"plan_code"`
-	Locale   string `json:"locale"`
+	PlanCode        string `json:"plan_code"`
+	BillingInterval string `json:"billing"`
+	Locale          string `json:"locale"`
 }
 
 type billingCheckoutSessionResponse struct {
@@ -189,7 +194,12 @@ func (h *handler) handleSignup() http.HandlerFunc {
 		req.GivenName = strings.TrimSpace(req.GivenName)
 		req.LastName = strings.TrimSpace(req.LastName)
 		req.TeamName = strings.TrimSpace(req.TeamName)
-		req.PlanCode = database.CloudPlanFree // signup always starts on free
+		requestedPlanCode := strings.TrimSpace(req.PlanCode)
+		if requestedPlanCode == "" {
+			requestedPlanCode = database.CloudPlanFree
+		}
+		req.PlanCode = normalizePlanCode(requestedPlanCode)
+		req.BillingInterval = normalizeBillingInterval(req.BillingInterval)
 		req.Jurisdiction = strings.TrimSpace(strings.ToUpper(req.Jurisdiction))
 		req.Locale = normalizeStripeLocale(req.Locale)
 		if req.TeamName == "" {
@@ -198,6 +208,10 @@ func (h *handler) handleSignup() http.HandlerFunc {
 
 		if req.Email == "" || len(req.Password) < 8 {
 			http.Error(w, "Email required; Password must be at least 8 characters", http.StatusBadRequest)
+			return
+		}
+		if req.PlanCode == "" {
+			http.Error(w, "Valid plan code is required", http.StatusBadRequest)
 			return
 		}
 		if !req.AcceptedTos {
@@ -223,14 +237,16 @@ func (h *handler) handleSignup() http.HandlerFunc {
 		}
 
 		token, err := h.ctx.Store.CreatePendingSignup(r.Context(), database.PendingSignupEntry{
-			Email:          req.Email,
-			HashedPassword: hashedPassword,
-			GivenName:      req.GivenName,
-			LastName:       req.LastName,
-			TeamName:       req.TeamName,
-			Jurisdiction:   req.Jurisdiction,
-			Locale:         req.Locale,
-			AcceptedTosAt:  time.Now().UTC(),
+			Email:           req.Email,
+			HashedPassword:  hashedPassword,
+			GivenName:       req.GivenName,
+			LastName:        req.LastName,
+			TeamName:        req.TeamName,
+			Jurisdiction:    req.Jurisdiction,
+			Locale:          req.Locale,
+			PlanCode:        req.PlanCode,
+			BillingInterval: req.BillingInterval,
+			AcceptedTosAt:   time.Now().UTC(),
 		})
 		if err != nil {
 			slog.Error("Failed to create pending signup token", "error", err, "email", req.Email)
@@ -246,8 +262,9 @@ func (h *handler) handleSignup() http.HandlerFunc {
 		}
 
 		resp := signupResponse{
-			Status:   "verification_sent",
-			PlanCode: database.CloudPlanFree,
+			Status:          "verification_sent",
+			PlanCode:        req.PlanCode,
+			BillingInterval: req.BillingInterval,
 		}
 
 		w.Header().Set("Content-Type", "application/json")
@@ -313,11 +330,20 @@ func (h *handler) handleVerifySignup() http.HandlerFunc {
 			TenantID:           account.TenantID,
 			PlanCode:           database.CloudPlanFree,
 			PlanName:           planNameForCode(database.CloudPlanFree),
+			BillingInterval:    normalizeBillingInterval(entry.BillingInterval),
 			SubscriptionStatus: database.CloudSubscriptionStatusFree,
 		}); err != nil {
 			slog.Error("Failed to initialize cloud billing account", "error", err, "team_id", account.TenantID)
 			http.Redirect(w, r, signupURL("expired"), http.StatusFound)
 			return
+		}
+		if _, err := h.ctx.Store.RecordCloudConversionEvent(r.Context(), database.CloudConversionEvent{
+			TenantID:        account.TenantID,
+			EventName:       database.CloudConversionSignupVerified,
+			PlanCode:        entry.PlanCode,
+			BillingInterval: entry.BillingInterval,
+		}); err != nil {
+			slog.Warn("Failed to record verified signup conversion", "error", err, "team_id", account.TenantID)
 		}
 
 		if err := issueLoginSession(w, h.ctx.Config, account.UserID); err != nil {
@@ -326,8 +352,16 @@ func (h *handler) handleVerifySignup() http.HandlerFunc {
 			return
 		}
 
-		dashboardURL := appurl.Path(h.ctx.Config.PublicURL, "/dashboard")
-		http.Redirect(w, r, dashboardURL, http.StatusFound)
+		if entry.PlanCode == database.CloudPlanPro || entry.PlanCode == database.CloudPlanBusiness {
+			query := url.Values{}
+			query.Set("plan", entry.PlanCode)
+			query.Set("billing", normalizeBillingInterval(entry.BillingInterval))
+			verifiedURL := appurl.Path(h.ctx.Config.PublicURL, "/signup/verified") + "?" + query.Encode()
+			http.Redirect(w, r, verifiedURL, http.StatusFound)
+			return
+		}
+
+		http.Redirect(w, r, appurl.Path(h.ctx.Config.PublicURL, "/dashboard"), http.StatusFound)
 	}
 }
 

--- a/internal/server/cloud/handlers_billing_events.go
+++ b/internal/server/cloud/handlers_billing_events.go
@@ -13,7 +13,7 @@ import (
 	"time"
 
 	"github.com/google/uuid"
-	stripe "github.com/stripe/stripe-go/v84"
+	stripe "github.com/stripe/stripe-go/v86"
 
 	"hitkeep/internal/api"
 	"hitkeep/internal/appurl"
@@ -86,12 +86,13 @@ func (h *handler) handleStripeEvent(ctx context.Context, event stripe.Event) err
 			TenantID:             tenantID,
 			PlanCode:             normalizePlanCode(session.Metadata["plan_code"]),
 			PlanName:             strings.TrimSpace(session.Metadata["plan_name"]),
+			BillingInterval:      normalizeBillingInterval(session.Metadata["billing_interval"]),
 			SubscriptionStatus:   session.Status,
 			StripeCustomerID:     session.Customer.ID,
 			StripeSubscriptionID: session.Subscription.ID,
 			StripePriceID:        session.FirstPriceID(),
 		})
-	case "customer.subscription.updated", "customer.subscription.deleted":
+	case "customer.subscription.created", "customer.subscription.updated", "customer.subscription.deleted":
 		subscription, err := parseStripeSubscriptionEvent(event.Data.Raw)
 		if err != nil {
 			handleErr = fmt.Errorf("decode subscription event: %w", err)
@@ -106,15 +107,20 @@ func (h *handler) handleStripeEvent(ctx context.Context, event stripe.Event) err
 		// portal plan switch changes the price but never rewrites the
 		// metadata written at the original checkout.
 		planCode := planCodeForPrice(h.ctx.Config, subscription.FirstPriceID())
+		billingInterval := billingIntervalForPrice(h.ctx.Config, subscription.FirstPriceID())
 		planName := planNameForCode(planCode)
 		if planCode == "" {
 			planCode = normalizePlanCode(subscription.Metadata["plan_code"])
 			planName = strings.TrimSpace(subscription.Metadata["plan_name"])
 		}
+		if billingInterval == "" {
+			billingInterval = normalizeBillingInterval(subscription.Metadata["billing_interval"])
+		}
 		handleErr = h.ctx.Store.UpsertCloudBillingAccount(ctx, database.CloudBillingAccount{
 			TenantID:             tenantID,
 			PlanCode:             planCode,
 			PlanName:             planName,
+			BillingInterval:      billingInterval,
 			SubscriptionStatus:   subscription.Status,
 			StripeCustomerID:     subscription.Customer.ID,
 			StripeSubscriptionID: subscription.ID,
@@ -140,6 +146,17 @@ func (h *handler) handleStripeEvent(ctx context.Context, event stripe.Event) err
 	}
 
 	if tenantID != uuid.Nil {
+		if account, err := h.ctx.Store.GetCloudBillingAccount(ctx, tenantID); err == nil && account != nil && account.SubscriptionStatus == database.CloudSubscriptionStatusActive {
+			if _, err := h.ctx.Store.RecordCloudConversionEvent(ctx, database.CloudConversionEvent{
+				TenantID:        tenantID,
+				EventName:       database.CloudConversionSubscriptionActivated,
+				PlanCode:        account.PlanCode,
+				BillingInterval: account.BillingInterval,
+				DedupeKey:       tenantID.String() + ":subscription_activated:" + account.StripeSubscriptionID,
+			}); err != nil {
+				slog.Error("failed to record subscription activation conversion", "tenant_id", tenantID, "stripe_event_id", event.ID, "error", err)
+			}
+		}
 		h.syncTeamRetentionAfterBillingChange(ctx, tenantID)
 	}
 
@@ -198,6 +215,15 @@ func normalizePlanCode(planCode string) string {
 	}
 }
 
+func normalizeBillingInterval(interval string) string {
+	switch strings.TrimSpace(strings.ToLower(interval)) {
+	case database.CloudBillingIntervalAnnual:
+		return database.CloudBillingIntervalAnnual
+	default:
+		return database.CloudBillingIntervalMonthly
+	}
+}
+
 func planNameForCode(planCode string) string {
 	return entitlements.CloudPlanName(normalizePlanCode(planCode))
 }
@@ -215,7 +241,17 @@ func stripeCustomerName(user *api.User, teamName string) string {
 	return strings.TrimSpace(teamName)
 }
 
-func priceIDForPlan(conf *config.Config, planCode string) string {
+func priceIDForPlan(conf *config.Config, planCode, billingInterval string) string {
+	if normalizeBillingInterval(billingInterval) == database.CloudBillingIntervalAnnual {
+		switch normalizePlanCode(planCode) {
+		case database.CloudPlanBusiness:
+			return strings.TrimSpace(conf.StripePriceBusinessAnnual)
+		case database.CloudPlanPro:
+			return strings.TrimSpace(conf.StripePriceProAnnual)
+		default:
+			return ""
+		}
+	}
 	switch normalizePlanCode(planCode) {
 	case database.CloudPlanBusiness:
 		return strings.TrimSpace(conf.StripePriceBusinessMonthly)
@@ -236,8 +272,27 @@ func planCodeForPrice(conf *config.Config, priceID string) string {
 	switch priceID {
 	case strings.TrimSpace(conf.StripePriceBusinessMonthly):
 		return database.CloudPlanBusiness
+	case strings.TrimSpace(conf.StripePriceBusinessAnnual):
+		return database.CloudPlanBusiness
 	case strings.TrimSpace(conf.StripePriceProMonthly):
 		return database.CloudPlanPro
+	case strings.TrimSpace(conf.StripePriceProAnnual):
+		return database.CloudPlanPro
+	default:
+		return ""
+	}
+}
+
+func billingIntervalForPrice(conf *config.Config, priceID string) string {
+	priceID = strings.TrimSpace(priceID)
+	if priceID == "" {
+		return ""
+	}
+	switch priceID {
+	case strings.TrimSpace(conf.StripePriceBusinessAnnual), strings.TrimSpace(conf.StripePriceProAnnual):
+		return database.CloudBillingIntervalAnnual
+	case strings.TrimSpace(conf.StripePriceBusinessMonthly), strings.TrimSpace(conf.StripePriceProMonthly):
+		return database.CloudBillingIntervalMonthly
 	default:
 		return ""
 	}

--- a/internal/server/cloud/handlers_billing_retention_test.go
+++ b/internal/server/cloud/handlers_billing_retention_test.go
@@ -7,7 +7,7 @@ import (
 	"testing"
 
 	"github.com/google/uuid"
-	stripe "github.com/stripe/stripe-go/v84"
+	stripe "github.com/stripe/stripe-go/v86"
 
 	"hitkeep/internal/database"
 )

--- a/internal/server/cloud/handlers_billing_sessions.go
+++ b/internal/server/cloud/handlers_billing_sessions.go
@@ -187,6 +187,7 @@ func (h *handler) handleCreateBillingCheckoutSession() http.HandlerFunc {
 		}
 
 		req.PlanCode = normalizePlanCode(req.PlanCode)
+		req.BillingInterval = normalizeBillingInterval(req.BillingInterval)
 		req.Locale = normalizeStripeLocale(req.Locale)
 		if req.PlanCode != database.CloudPlanPro && req.PlanCode != database.CloudPlanBusiness {
 			http.Error(w, "Paid plan code is required", http.StatusBadRequest)
@@ -231,24 +232,24 @@ func (h *handler) handleCreateBillingCheckoutSession() http.HandlerFunc {
 			}
 		}
 
-		priceID := priceIDForPlan(h.ctx.Config, req.PlanCode)
+		priceID := priceIDForPlan(h.ctx.Config, req.PlanCode, req.BillingInterval)
 		if priceID == "" {
 			http.Error(w, "Plan is not configured for checkout", http.StatusBadRequest)
 			return
 		}
 
 		session, err := h.stripe.CreateCheckoutSession(r.Context(), createCheckoutSessionInput{
-			CustomerID:   customerID,
-			PriceID:      priceID,
-			SuccessURL:   checkoutSuccessURL(h.ctx.Config),
-			CancelURL:    checkoutCancelURL(h.ctx.Config),
-			Locale:       req.Locale,
-			UserID:       user.ID,
-			TenantID:     activeTenantID,
-			PlanCode:     req.PlanCode,
-			PlanName:     planNameForCode(req.PlanCode),
-			Jurisdiction: strings.TrimSpace(strings.ToUpper(h.ctx.Config.CloudJurisdiction)),
-			Email:        strings.TrimSpace(strings.ToLower(user.Email)),
+			CustomerID:      customerID,
+			PriceID:         priceID,
+			SuccessURL:      checkoutSuccessURL(h.ctx.Config),
+			CancelURL:       checkoutCancelURL(h.ctx.Config),
+			Locale:          req.Locale,
+			UserID:          user.ID,
+			TenantID:        activeTenantID,
+			PlanCode:        req.PlanCode,
+			PlanName:        planNameForCode(req.PlanCode),
+			BillingInterval: req.BillingInterval,
+			Jurisdiction:    strings.TrimSpace(strings.ToUpper(h.ctx.Config.CloudJurisdiction)),
 		})
 		if err != nil {
 			slog.Error("Failed to create Stripe upgrade checkout session", "error", err)
@@ -260,6 +261,7 @@ func (h *handler) handleCreateBillingCheckoutSession() http.HandlerFunc {
 			TenantID:             activeTenantID,
 			PlanCode:             database.CloudPlanFree,
 			PlanName:             planNameForCode(database.CloudPlanFree),
+			BillingInterval:      req.BillingInterval,
 			SubscriptionStatus:   subscriptionStatusPending,
 			StripeCustomerID:     customerID,
 			StripeSubscriptionID: "",
@@ -268,6 +270,15 @@ func (h *handler) handleCreateBillingCheckoutSession() http.HandlerFunc {
 			slog.Error("Failed to persist Stripe upgrade checkout metadata", "error", err)
 			http.Error(w, "Internal server error", http.StatusInternalServerError)
 			return
+		}
+		if _, err := h.ctx.Store.RecordCloudConversionEvent(r.Context(), database.CloudConversionEvent{
+			TenantID:        activeTenantID,
+			EventName:       database.CloudConversionCheckoutStarted,
+			PlanCode:        req.PlanCode,
+			BillingInterval: req.BillingInterval,
+			DedupeKey:       activeTenantID.String() + ":checkout:" + session.ID,
+		}); err != nil {
+			slog.Warn("Failed to record checkout conversion", "error", err, "team_id", activeTenantID, "checkout_session_id", session.ID)
 		}
 
 		w.Header().Set("Content-Type", "application/json")

--- a/internal/server/cloud/handlers_billing_test.go
+++ b/internal/server/cloud/handlers_billing_test.go
@@ -18,8 +18,8 @@ import (
 	"time"
 
 	"github.com/google/uuid"
-	stripe "github.com/stripe/stripe-go/v84"
-	"github.com/stripe/stripe-go/v84/webhook"
+	stripe "github.com/stripe/stripe-go/v86"
+	"github.com/stripe/stripe-go/v86/webhook"
 	"golang.org/x/time/rate"
 
 	"hitkeep/internal/config"
@@ -120,6 +120,8 @@ func setupCloudTestHandler(t *testing.T) (*handler, *database.Store) {
 		StripeWebhookSecret:         "whsec_test_123",
 		StripePriceProMonthly:       "price_pro",
 		StripePriceBusinessMonthly:  "price_business",
+		StripePriceProAnnual:        "price_pro_annual",
+		StripePriceBusinessAnnual:   "price_business_annual",
 	}
 
 	h := &handler{
@@ -586,20 +588,21 @@ func TestHandleVerifySignupInvalidToken(t *testing.T) {
 	}
 }
 
-func TestHandleSignupForcesFreeEvenWhenPaidPlanRequested(t *testing.T) {
+func TestHandleSignupPreservesPaidAnnualIntentWithoutStartingCheckout(t *testing.T) {
 	h, store := setupCloudTestHandler(t)
 	defer store.Close()
 
 	body, err := json.Marshal(signupRequest{
-		Email:        "pro@example.com",
-		Password:     "password123",
-		GivenName:    "Pro",
-		LastName:     "User",
-		TeamName:     "Pro Team",
-		PlanCode:     database.CloudPlanPro,
-		Jurisdiction: "EU",
-		Locale:       "de-DE",
-		AcceptedTos:  true,
+		Email:           "pro@example.com",
+		Password:        "password123",
+		GivenName:       "Pro",
+		LastName:        "User",
+		TeamName:        "Pro Team",
+		PlanCode:        database.CloudPlanPro,
+		BillingInterval: database.CloudBillingIntervalAnnual,
+		Jurisdiction:    "EU",
+		Locale:          "de-DE",
+		AcceptedTos:     true,
 	})
 	if err != nil {
 		t.Fatalf("marshal request: %v", err)
@@ -620,8 +623,11 @@ func TestHandleSignupForcesFreeEvenWhenPaidPlanRequested(t *testing.T) {
 	if resp.Status != "verification_sent" {
 		t.Fatalf("expected status verification_sent, got %q", resp.Status)
 	}
-	if resp.PlanCode != database.CloudPlanFree {
-		t.Fatalf("expected free plan code, got %q", resp.PlanCode)
+	if resp.PlanCode != database.CloudPlanPro {
+		t.Fatalf("expected pro plan code, got %q", resp.PlanCode)
+	}
+	if resp.BillingInterval != database.CloudBillingIntervalAnnual {
+		t.Fatalf("expected annual billing interval, got %q", resp.BillingInterval)
 	}
 
 	stripeClient, ok := h.stripe.(*fakeStripeClient)
@@ -633,6 +639,36 @@ func TestHandleSignupForcesFreeEvenWhenPaidPlanRequested(t *testing.T) {
 	}
 	if stripeClient.lastCustomerInput != nil {
 		t.Fatal("expected no stripe customer to be created during signup")
+	}
+}
+
+func TestHandleVerifySignupRedirectsPaidIntentToCheckoutBridge(t *testing.T) {
+	h, store := setupCloudTestHandler(t)
+	defer store.Close()
+
+	token, err := store.CreatePendingSignup(context.Background(), database.PendingSignupEntry{
+		Email:           "annual-pro@example.com",
+		HashedPassword:  "$2a$10$testhashedpassword",
+		TeamName:        "Annual Pro Team",
+		Jurisdiction:    "EU",
+		Locale:          "en",
+		PlanCode:        database.CloudPlanPro,
+		BillingInterval: database.CloudBillingIntervalAnnual,
+	})
+	if err != nil {
+		t.Fatalf("create pending signup: %v", err)
+	}
+
+	req := httptest.NewRequest(http.MethodGet, "/api/cloud/signup/verify?token="+token, nil)
+	w := httptest.NewRecorder()
+	h.handleVerifySignup().ServeHTTP(w, req)
+
+	if w.Code != http.StatusFound {
+		t.Fatalf("expected redirect status %d, got %d: %s", http.StatusFound, w.Code, w.Body.String())
+	}
+	location := w.Header().Get("Location")
+	if location != "https://cloud.hitkeep.eu/signup/verified?billing=annual&plan=pro" {
+		t.Fatalf("expected paid checkout bridge redirect, got %q", location)
 	}
 }
 
@@ -954,7 +990,7 @@ func TestHandleStripeWebhookSignedSubscriptionLifecycle(t *testing.T) {
 		t.Fatalf("seed billing account: %v", err)
 	}
 
-	activate := postSignedStripeWebhook(t, h, "evt_sub_updated", "customer.subscription.updated", map[string]any{
+	activate := postSignedStripeWebhook(t, h, "evt_sub_created", "customer.subscription.created", map[string]any{
 		"id": "sub_live",
 		"metadata": map[string]string{
 			"tenant_id":    account.TenantID.String(),
@@ -984,8 +1020,15 @@ func TestHandleStripeWebhookSignedSubscriptionLifecycle(t *testing.T) {
 	if billingAccount.StripeSubscriptionID != "sub_live" || billingAccount.StripePriceID != "price_pro" {
 		t.Fatalf("expected subscription identifiers to be stored, got %+v", billingAccount)
 	}
+	conversionEvents, err := store.ListCloudConversionEvents(context.Background(), account.TenantID)
+	if err != nil {
+		t.Fatalf("list subscription conversion events: %v", err)
+	}
+	if len(conversionEvents) != 1 || conversionEvents[0].EventName != database.CloudConversionSubscriptionActivated || conversionEvents[0].PlanCode != database.CloudPlanPro || conversionEvents[0].BillingInterval != database.CloudBillingIntervalMonthly {
+		t.Fatalf("expected one Pro monthly subscription activation, got %+v", conversionEvents)
+	}
 
-	replayed := postSignedStripeWebhook(t, h, "evt_sub_updated", "customer.subscription.updated", map[string]any{
+	replayed := postSignedStripeWebhook(t, h, "evt_sub_created", "customer.subscription.created", map[string]any{
 		"id": "sub_live",
 		"metadata": map[string]string{
 			"tenant_id": account.TenantID.String(),
@@ -1023,7 +1066,7 @@ func TestHandleStripeWebhookSignedSubscriptionLifecycle(t *testing.T) {
 		t.Fatalf("expected past_due status, got %+v", billingAccount)
 	}
 
-	storedEvent, err := store.GetCloudBillingEvent(context.Background(), "evt_sub_updated")
+	storedEvent, err := store.GetCloudBillingEvent(context.Background(), "evt_sub_created")
 	if err != nil {
 		t.Fatalf("get replayed billing event: %v", err)
 	}
@@ -1264,7 +1307,11 @@ func TestHandleCreateBillingCheckoutSession(t *testing.T) {
 		t.Fatalf("upsert cloud billing account: %v", err)
 	}
 
-	body, err := json.Marshal(billingCheckoutSessionRequest{PlanCode: database.CloudPlanPro, Locale: "de-DE"})
+	body, err := json.Marshal(billingCheckoutSessionRequest{
+		PlanCode:        database.CloudPlanPro,
+		BillingInterval: database.CloudBillingIntervalAnnual,
+		Locale:          "de-DE",
+	})
 	if err != nil {
 		t.Fatalf("marshal request: %v", err)
 	}
@@ -1306,6 +1353,12 @@ func TestHandleCreateBillingCheckoutSession(t *testing.T) {
 	if stripeClient.lastCheckoutInput.PlanCode != database.CloudPlanPro {
 		t.Fatalf("expected checkout plan %q, got %q", database.CloudPlanPro, stripeClient.lastCheckoutInput.PlanCode)
 	}
+	if stripeClient.lastCheckoutInput.BillingInterval != database.CloudBillingIntervalAnnual {
+		t.Fatalf("expected annual checkout interval, got %q", stripeClient.lastCheckoutInput.BillingInterval)
+	}
+	if stripeClient.lastCheckoutInput.PriceID != "price_pro_annual" {
+		t.Fatalf("expected annual Pro price, got %q", stripeClient.lastCheckoutInput.PriceID)
+	}
 	if stripeClient.lastCheckoutInput.SuccessURL != "https://cloud.hitkeep.eu/hitkeep/admin/team?checkout=success" {
 		t.Fatalf("expected prefixed checkout success URL, got %q", stripeClient.lastCheckoutInput.SuccessURL)
 	}
@@ -1326,8 +1379,11 @@ func TestHandleCreateBillingCheckoutSession(t *testing.T) {
 	if storedAccount.StripeCustomerID != "cus_test" {
 		t.Fatalf("expected persisted customer id cus_test, got %q", storedAccount.StripeCustomerID)
 	}
-	if storedAccount.StripePriceID != "price_pro" {
-		t.Fatalf("expected persisted price id price_pro, got %q", storedAccount.StripePriceID)
+	if storedAccount.StripePriceID != "price_pro_annual" {
+		t.Fatalf("expected persisted price id price_pro_annual, got %q", storedAccount.StripePriceID)
+	}
+	if storedAccount.BillingInterval != database.CloudBillingIntervalAnnual {
+		t.Fatalf("expected persisted annual interval, got %q", storedAccount.BillingInterval)
 	}
 }
 

--- a/internal/server/cloud/stripe_client.go
+++ b/internal/server/cloud/stripe_client.go
@@ -10,8 +10,8 @@ import (
 	"strings"
 
 	"github.com/google/uuid"
-	stripe "github.com/stripe/stripe-go/v84"
-	"github.com/stripe/stripe-go/v84/webhook"
+	stripe "github.com/stripe/stripe-go/v86"
+	"github.com/stripe/stripe-go/v86/webhook"
 )
 
 func (c *stripeSDKClient) CreateCustomer(ctx context.Context, input createCustomerInput) (string, error) {
@@ -24,6 +24,7 @@ func (c *stripeSDKClient) CreateCustomer(ctx context.Context, input createCustom
 	params.AddMetadata("user_id", input.UserID.String())
 	params.AddMetadata("tenant_id", input.TenantID.String())
 	params.AddMetadata("plan_code", input.PlanCode)
+	params.AddMetadata("billing_interval", input.BillingInterval)
 	params.AddMetadata("jurisdiction", input.Jurisdiction)
 
 	created, err := c.client.V1Customers.Create(ctx, params)
@@ -47,11 +48,12 @@ func (c *stripeSDKClient) CreateCheckoutSession(ctx context.Context, input creat
 		},
 		SubscriptionData: &stripe.CheckoutSessionCreateSubscriptionDataParams{
 			Metadata: map[string]string{
-				"user_id":      input.UserID.String(),
-				"tenant_id":    input.TenantID.String(),
-				"plan_code":    input.PlanCode,
-				"plan_name":    input.PlanName,
-				"jurisdiction": input.Jurisdiction,
+				"user_id":          input.UserID.String(),
+				"tenant_id":        input.TenantID.String(),
+				"plan_code":        input.PlanCode,
+				"plan_name":        input.PlanName,
+				"billing_interval": input.BillingInterval,
+				"jurisdiction":     input.Jurisdiction,
 			},
 		},
 		CustomerUpdate: &stripe.CheckoutSessionCreateCustomerUpdateParams{
@@ -65,8 +67,8 @@ func (c *stripeSDKClient) CreateCheckoutSession(ctx context.Context, input creat
 	params.AddMetadata("tenant_id", input.TenantID.String())
 	params.AddMetadata("plan_code", input.PlanCode)
 	params.AddMetadata("plan_name", input.PlanName)
+	params.AddMetadata("billing_interval", input.BillingInterval)
 	params.AddMetadata("jurisdiction", input.Jurisdiction)
-	params.AddMetadata("email", input.Email)
 
 	created, err := c.client.V1CheckoutSessions.Create(ctx, params)
 	if err != nil {

--- a/internal/server/sites/handlers.go
+++ b/internal/server/sites/handlers.go
@@ -278,6 +278,12 @@ func (h *handler) handleCreateSite() http.HandlerFunc {
 		}
 
 		if teamID, err := h.ctx.Store.GetSiteTenantID(r.Context(), site.ID); err == nil {
+			if _, conversionErr := h.ctx.Store.RecordCloudConversionEvent(r.Context(), database.CloudConversionEvent{
+				TenantID:  teamID,
+				EventName: database.CloudConversionFirstSiteCreated,
+			}); conversionErr != nil {
+				slog.Warn("Failed to record first site conversion", "error", conversionErr, "team_id", teamID, "site_id", site.ID)
+			}
 			h.ctx.AppendAuditEvent(r.Context(), r, shared.AuditEvent{
 				ActorID:     userID,
 				TeamID:      teamID,


### PR DESCRIPTION
## Summary
- add €150 Pro and €390 Business annual billing throughout signup, verification, account upgrades, Stripe Checkout, and subscription state
- preserve paid plan and billing intent through verification, then route paid-intent users to Checkout with a visible Free fallback
- record privacy-safe conversion milestones for verification, first site, first hit, checkout, and activation
- fix filtered goal conversions to use the report session cohort
- keep Free entitlements unchanged and localize the new billing UI in all seven dashboard languages
- upgrade stripe-go from v84 to v86

## QA
- PR-parity `hk qa pr` is running against clean commit `784eb3f`
- focused billing, signup, analytics, i18n, and dashboard coverage is included in the diff

## Deployment dependency
Requires the annual Stripe price/SSM infra changes from `PascaleBeier/hitkeep-infra#1` before the application release is deployed.