### PR TITLE
chore(security): refresh default spam filter data

### DIFF
--- a/internal/blocking/default_spam_filter.json
+++ b/internal/blocking/default_spam_filter.json
@@ -1,5 +1,5 @@
 {
-  "generated_at": "2026-07-29T11:29:38.438989Z",
+  "generated_at": "2026-08-01T20:03:55.361199044Z",
   "sources": {
     "matomo_referrer_spam_list": "https://raw.githubusercontent.com/matomo-org/referrer-spam-list/master/spammers.txt",
     "spamhaus_drop": "https://www.spamhaus.org/drop/drop_v4.json",
@@ -7,12 +7,12 @@
   },
   "source_metadata": {
     "spamhaus_drop": {
-      "timestamp": 1785249842,
+      "timestamp": 1785564842,
       "copyright": "(c) 2026 The Spamhaus Project SLU",
       "terms": "https://www.spamhaus.org/drop/terms/"
     },
     "spamhaus_dropv6": {
-      "timestamp": 1785262442,
+      "timestamp": 1785563042,
       "copyright": "(c) 2026 The Spamhaus Project SLU",
       "terms": "https://www.spamhaus.org/drop/terms/"
     }
@@ -2747,7 +2747,6 @@
     "160.14.0.0/16",
     "160.180.0.0/16",
     "160.188.0.0/16",
-    "160.21.0.0/16",
     "160.240.0.0/16",
     "160.65.0.0/16",
     "161.0.0.0/19",
@@ -4020,7 +4019,6 @@
     "86.107.72.0/24",
     "86.111.228.0/24",
     "86.54.25.0/24",
-    "87.121.79.0/24",
     "87.121.84.0/24",
     "87.228.109.0/24",
     "87.228.110.0/24",


### PR DESCRIPTION
Refreshes HitKeep's embedded Matomo referrer-spam and Spamhaus DROP datasets.

Generated with:

```sh
./scripts/update-default-spam-filter.sh
```