### PR TITLE
chore(analytics): refresh default AI agent list data

### DIFF
--- a/internal/aianalytics/default_ai_agents.json
+++ b/internal/aianalytics/default_ai_agents.json
@@ -1,5 +1,5 @@
 {
-  "generated_at": "2026-07-29T11:29:39.505474Z",
+  "generated_at": "2026-08-01T21:00:01.296369489Z",
   "sources": {
     "ai_robots_txt": "https://raw.githubusercontent.com/ai-robots-txt/ai.robots.txt/main/robots.json",
     "crawler_user_agents": "https://raw.githubusercontent.com/monperrus/crawler-user-agents/master/crawler-user-agents.json",
@@ -1180,12 +1180,11 @@
     {
       "token": "iboubot",
       "name": "IbouBot",
-      "family": "Ibou",
+      "family": "IbouBot",
       "category": "ai_search_indexer",
-      "respects_robots_txt": "yes",
+      "respects_robots_txt": "unclear",
       "url": "https://ibou.io/iboubot.html",
       "sources": [
-        "ai_robots_txt",
         "device_detector_bots"
       ]
     },
@@ -2233,8 +2232,8 @@
     },
     {
       "token": "webzio-extended",
-      "name": "Webzio-Extended",
-      "family": "Webzio-Extended",
+      "name": "webzio-extended",
+      "family": "webzio-extended",
       "category": "ai_training_crawler",
       "respects_robots_txt": "unclear",
       "url": "https://docs.webz.io/reference/how-it-works-video",


### PR DESCRIPTION
Refreshes HitKeep's embedded AI agent master list assembled from ai.robots.txt, device-detector, and crawler-user-agents.

Generated with:

```sh
./scripts/update-default-ai-agents.sh
```