### PR TITLE
fix(release): stage candidates as prereleases

### DIFF
--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -285,6 +285,7 @@ jobs:
           cp "$release_inputs/hitkeep-configuration.json" .
           cp "$release_inputs/hitkeep.example.yaml" .
           cp "$release_inputs/hitkeep-configuration-manifest.json" .
+          printf '%s\n' hitkeep-configuration.json hitkeep-configuration-manifest.json >> .git/info/exclude
 
       - name: Build and verify GoReleaser release archives
         id: release-artifacts

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -558,11 +558,11 @@ jobs:
               "$source"
           done
 
-      - name: Publish draft GitHub release
+      - name: Promote GitHub release
         env:
           GH_TOKEN: ${{ github.token }}
           TAG: ${{ needs.release-please.outputs.tag_name }}
-        run: gh release edit "$TAG" --draft=false --latest
+        run: gh release edit "$TAG" --prerelease=false --latest
 
   sync-docs-release:
     name: Publish release and configuration metadata to docs

--- a/internal/devtool/docs.go
+++ b/internal/devtool/docs.go
@@ -24,9 +24,11 @@ var dockerfileVolumePattern = regexp.MustCompile(`(?m)^\s*VOLUME\s+(.+)$`)
 var dockerfileQuotedPathPattern = regexp.MustCompile(`"([^"]+)"`)
 
 type releasePleaseConfig struct {
-	Draft    bool `json:"draft"`
-	Packages map[string]struct {
+	Draft      bool `json:"draft"`
+	Prerelease bool `json:"prerelease"`
+	Packages   map[string]struct {
 		Draft      *bool                    `json:"draft"`
+		Prerelease *bool                    `json:"prerelease"`
 		ExtraFiles []releasePleaseExtraFile `json:"extra-files"`
 	} `json:"packages"`
 }
@@ -185,6 +187,15 @@ func validateReleaseWorkflowGraph(raw []byte) error {
 	if !trackerDownload || !trackerPublish {
 		return fmt.Errorf("release workflow finalizer must publish the verified tracker artifact with npm integrity verification")
 	}
+	prereleasePromotion := false
+	for _, step := range finalizer.Steps {
+		if step.Name == "Promote GitHub release" && strings.Contains(step.Run, `gh release edit "$TAG" --prerelease=false --latest`) {
+			prereleasePromotion = true
+		}
+	}
+	if !prereleasePromotion {
+		return fmt.Errorf("release workflow finalizer must promote the prerelease to latest")
+	}
 	for _, step := range finalizer.Steps {
 		for _, values := range []map[string]string{step.Env, step.With} {
 			for _, value := range values {
@@ -202,7 +213,7 @@ func validateReleaseWorkflowGraph(raw []byte) error {
 		"Publish immutable tracker candidate",
 		"Promote tracker latest dist-tag",
 		"Promote immutable image to mutable tags",
-		"Publish draft GitHub release",
+		"Promote GitHub release",
 	}
 	previous := -1
 	previousName := ""
@@ -700,8 +711,15 @@ func validateReleaseMetadata(root string) error {
 	if rootPackageConfig.Draft != nil {
 		effectiveDraft = *rootPackageConfig.Draft
 	}
-	if !effectiveDraft {
-		return fmt.Errorf("release-please-config.json effective packages['.'].draft must be true")
+	if effectiveDraft {
+		return fmt.Errorf("release-please-config.json effective packages['.'].draft must be false")
+	}
+	effectivePrerelease := config.Prerelease
+	if rootPackageConfig.Prerelease != nil {
+		effectivePrerelease = *rootPackageConfig.Prerelease
+	}
+	if !effectivePrerelease {
+		return fmt.Errorf("release-please-config.json effective packages['.'].prerelease must be true")
 	}
 	expectedFiles := []releasePleaseExtraFile{
 		{Type: "json", Path: "server.json", JSONPath: "$.version"},
@@ -733,6 +751,8 @@ func validateReleaseMetadata(root string) error {
 			"hitkeep-configuration-manifest.json",
 			"release_tag: $tag",
 			"release_version: $version",
+			"printf '%s\\n' hitkeep-configuration.json hitkeep-configuration-manifest.json >> .git/info/exclude",
+			"github.com/goreleaser/goreleaser/v2@v2.18.0 release --clean --skip=publish",
 		},
 		".github/workflows/release.yml": {
 			"finalize-release:",
@@ -752,6 +772,18 @@ func validateReleaseMetadata(root string) error {
 		if name == ".github/workflows/pipeline.yml" && bytes.Contains(raw, []byte("./hk ci build-binaries")) {
 			return fmt.Errorf(".github/workflows/pipeline.yml must not run ./hk ci build-binaries")
 		}
+	}
+	pipelineRaw, err := os.ReadFile(filepath.Join(root, ".github", "workflows", "pipeline.yml"))
+	if err != nil {
+		return err
+	}
+	pipeline := string(pipelineRaw)
+	const runnerLocalExclude = "printf '%s\\n' hitkeep-configuration.json hitkeep-configuration-manifest.json >> .git/info/exclude"
+	if strings.Count(pipeline, ".git/info/exclude") != 1 || !strings.Contains(pipeline, runnerLocalExclude) {
+		return fmt.Errorf(".github/workflows/pipeline.yml must write exactly the generated configuration JSON inputs to .git/info/exclude")
+	}
+	if strings.Index(pipeline, runnerLocalExclude) >= strings.Index(pipeline, "github.com/goreleaser/goreleaser/v2@v2.18.0 release --clean --skip=publish") {
+		return fmt.Errorf(".github/workflows/pipeline.yml must write generated configuration JSON inputs to .git/info/exclude before tagged GoReleaser")
 	}
 	goreleaserManifest, err := os.ReadFile(filepath.Join(root, ".goreleaser.yaml"))
 	if err != nil {

--- a/internal/devtool/docs_test.go
+++ b/internal/devtool/docs_test.go
@@ -64,12 +64,12 @@ func TestValidateReleaseMetadata(t *testing.T) {
 		}
 	})
 
-	t.Run("root package draft override", func(t *testing.T) {
+	t.Run("draft candidate is rejected", func(t *testing.T) {
 		root := releaseMetadataFixture(t)
-		config := strings.Replace(fixtureReleasePleaseConfig(), `".":{`, `".":{"draft":false,`, 1)
+		config := strings.Replace(fixtureReleasePleaseConfig(), `".":{"draft":false`, `".":{"draft":true`, 1)
 		writeFixtureFile(t, root, "release-please-config.json", config)
 		err := validateReleaseMetadata(root)
-		if err == nil || !strings.Contains(err.Error(), "effective packages['.'].draft must be true") {
+		if err == nil || !strings.Contains(err.Error(), "effective packages['.'].draft must be false") {
 			t.Fatalf("unexpected error: %v", err)
 		}
 	})
@@ -83,9 +83,61 @@ func TestValidateReleaseMetadata(t *testing.T) {
 		}
 	})
 
+	t.Run("generated configuration inputs must remain runner-local ignores", func(t *testing.T) {
+		root := releaseMetadataFixture(t)
+		workflow, err := os.ReadFile(filepath.Join(root, ".github", "workflows", "pipeline.yml"))
+		if err != nil {
+			t.Fatal(err)
+		}
+		writeFixtureFile(t, root, ".github/workflows/pipeline.yml", strings.Replace(string(workflow), " >> .git/info/exclude", "", 1))
+		err = validateReleaseMetadata(root)
+		if err == nil || !strings.Contains(err.Error(), ".git/info/exclude") {
+			t.Fatalf("unexpected error: %v", err)
+		}
+	})
+
+	t.Run("runner-local configuration excludes reject missing paths", func(t *testing.T) {
+		root := releaseMetadataFixture(t)
+		workflow, err := os.ReadFile(filepath.Join(root, ".github", "workflows", "pipeline.yml"))
+		if err != nil {
+			t.Fatal(err)
+		}
+		invalid := strings.Replace(string(workflow), "hitkeep-configuration.json hitkeep-configuration-manifest.json", "hitkeep-configuration-manifest.json", 1)
+		writeFixtureFile(t, root, ".github/workflows/pipeline.yml", invalid)
+		if err := validateReleaseMetadata(root); err == nil {
+			t.Fatal("validateReleaseMetadata() accepted a missing runner-local configuration exclude")
+		}
+	})
+
+	t.Run("runner-local configuration excludes reject additional paths", func(t *testing.T) {
+		root := releaseMetadataFixture(t)
+		workflow, err := os.ReadFile(filepath.Join(root, ".github", "workflows", "pipeline.yml"))
+		if err != nil {
+			t.Fatal(err)
+		}
+		writeFixtureFile(t, root, ".github/workflows/pipeline.yml", string(workflow)+"\nprintf '%s\\n' unrelated-path >> .git/info/exclude\n")
+		if err := validateReleaseMetadata(root); err == nil {
+			t.Fatal("validateReleaseMetadata() accepted an additional runner-local configuration exclude")
+		}
+	})
+
+	t.Run("runner-local configuration excludes precede tagged release", func(t *testing.T) {
+		root := releaseMetadataFixture(t)
+		workflow, err := os.ReadFile(filepath.Join(root, ".github", "workflows", "pipeline.yml"))
+		if err != nil {
+			t.Fatal(err)
+		}
+		const exclude = "printf '%s\\n' hitkeep-configuration.json hitkeep-configuration-manifest.json >> .git/info/exclude"
+		invalid := strings.Replace(string(workflow), exclude, "", 1) + "\n" + exclude + "\n"
+		writeFixtureFile(t, root, ".github/workflows/pipeline.yml", invalid)
+		if err := validateReleaseMetadata(root); err == nil {
+			t.Fatal("validateReleaseMetadata() accepted a late runner-local configuration exclude")
+		}
+	})
+
 	t.Run("manual release build is rejected", func(t *testing.T) {
 		root := releaseMetadataFixture(t)
-		writeFixtureFile(t, root, ".github/workflows/pipeline.yml", "github.com/goreleaser/goreleaser/v2@v2.18.0\n--snapshot\n--clean\n--single-target\n--id self-hosted\n--id cloud\n./hk catalog configuration --output json\n./hk catalog configuration-manifest\nhitkeep-configuration.json\nhitkeep.example.yaml\nhitkeep-configuration-manifest.json\nrelease_tag: $tag\nrelease_version: $version\n./hk ci build-binaries\n")
+		writeFixtureFile(t, root, ".github/workflows/pipeline.yml", "github.com/goreleaser/goreleaser/v2@v2.18.0\n--snapshot\n--clean\n--single-target\n--id self-hosted\n--id cloud\n./hk catalog configuration --output json\n./hk catalog configuration-manifest\nhitkeep-configuration.json\nhitkeep.example.yaml\nhitkeep-configuration-manifest.json\nrelease_tag: $tag\nrelease_version: $version\nprintf '%s\\n' hitkeep-configuration.json hitkeep-configuration-manifest.json >> .git/info/exclude\ngithub.com/goreleaser/goreleaser/v2@v2.18.0 release --clean --skip=publish\n./hk ci build-binaries\n")
 		err := validateReleaseMetadata(root)
 		if err == nil || !strings.Contains(err.Error(), ".github/workflows/pipeline.yml must not run ./hk ci build-binaries") {
 			t.Fatalf("unexpected error: %v", err)
@@ -94,7 +146,7 @@ func TestValidateReleaseMetadata(t *testing.T) {
 
 	t.Run("missing example configuration release asset", func(t *testing.T) {
 		root := releaseMetadataFixture(t)
-		writeFixtureFile(t, root, ".github/workflows/pipeline.yml", "github.com/goreleaser/goreleaser/v2@v2.18.0\n--snapshot\n--clean\n--single-target\n--id self-hosted\n--id cloud\n./hk catalog configuration --output json\n./hk catalog configuration-manifest\nhitkeep-configuration.json\nhitkeep-configuration-manifest.json\nrelease_tag: $tag\nrelease_version: $version\n")
+		writeFixtureFile(t, root, ".github/workflows/pipeline.yml", "github.com/goreleaser/goreleaser/v2@v2.18.0\n--snapshot\n--clean\n--single-target\n--id self-hosted\n--id cloud\n./hk catalog configuration --output json\n./hk catalog configuration-manifest\nhitkeep-configuration.json\nhitkeep-configuration-manifest.json\nrelease_tag: $tag\nrelease_version: $version\nprintf '%s\\n' hitkeep-configuration.json hitkeep-configuration-manifest.json >> .git/info/exclude\ngithub.com/goreleaser/goreleaser/v2@v2.18.0 release --clean --skip=publish\n")
 		err := validateReleaseMetadata(root)
 		if err == nil || !strings.Contains(err.Error(), `.github/workflows/pipeline.yml is missing release metadata contract "hitkeep.example.yaml"`) {
 			t.Fatalf("unexpected error: %v", err)
@@ -247,7 +299,7 @@ func releaseMetadataFixture(t *testing.T) string {
 	writeFixtureFile(t, root, "charts/hitkeep/README.md", "tag: 2.12.0 # x-release-please-version\n")
 	writeFixtureFile(t, root, "release-please-config.json", fixtureReleasePleaseConfig())
 	writeFixtureFile(t, root, ".goreleaser.yaml", "files:\n  - hitkeep-configuration.json\n  - hitkeep.example.yaml\n  - hitkeep-configuration-manifest.json\n")
-	writeFixtureFile(t, root, ".github/workflows/pipeline.yml", "github.com/goreleaser/goreleaser/v2@v2.18.0\n--snapshot\n--clean\n--single-target\n--id self-hosted\n--id cloud\n./hk catalog configuration --output json\n./hk catalog configuration-manifest\nhitkeep-configuration.json\nhitkeep.example.yaml\nhitkeep-configuration-manifest.json\nrelease_tag: $tag\nrelease_version: $version\n")
+	writeFixtureFile(t, root, ".github/workflows/pipeline.yml", "github.com/goreleaser/goreleaser/v2@v2.18.0\n--snapshot\n--clean\n--single-target\n--id self-hosted\n--id cloud\n./hk catalog configuration --output json\n./hk catalog configuration-manifest\nhitkeep-configuration.json\nhitkeep.example.yaml\nhitkeep-configuration-manifest.json\nrelease_tag: $tag\nrelease_version: $version\nprintf '%s\\n' hitkeep-configuration.json hitkeep-configuration-manifest.json >> .git/info/exclude\ngithub.com/goreleaser/goreleaser/v2@v2.18.0 release --clean --skip=publish\n")
 	writeFixtureFile(t, root, ".github/workflows/release.yml", `# sync-hitkeep-release.yml
 jobs:
   release-please: {}
@@ -344,7 +396,8 @@ jobs:
           npm view @hitkeep/tracker dist.integrity
       - name: Promote tracker latest dist-tag
       - name: Promote immutable image to mutable tags
-      - name: Publish draft GitHub release
+      - name: Promote GitHub release
+        run: gh release edit "$TAG" --prerelease=false --latest
   sync-docs-release:
     needs:
       - finalize-release
@@ -376,7 +429,7 @@ jobs: {}
 }
 
 func fixtureReleasePleaseConfig() string {
-	return `{"draft":true,"packages":{".":{"extra-files":[{"type":"json","path":"server.json","jsonpath":"$.version"},{"type":"json","path":"frontend/dashboard/package.json","jsonpath":"$.version"},{"type":"json","path":"frontend/dashboard/package-lock.json","jsonpath":"$['packages']['']['version']"},{"type":"json","path":"frontend/tracker/package.json","jsonpath":"$.version"},{"type":"generic","path":"frontend/dashboard/src/tracker/version.ts"},{"type":"yaml","path":"charts/hitkeep/Chart.yaml","jsonpath":"$.version"},{"type":"yaml","path":"charts/hitkeep/Chart.yaml","jsonpath":"$.appVersion"},{"type":"generic","path":"charts/hitkeep/README.md"}]}}}`
+	return `{"draft":false,"prerelease":true,"packages":{".":{"draft":false,"prerelease":true,"extra-files":[{"type":"json","path":"server.json","jsonpath":"$.version"},{"type":"json","path":"frontend/dashboard/package.json","jsonpath":"$.version"},{"type":"json","path":"frontend/dashboard/package-lock.json","jsonpath":"$['packages']['']['version']"},{"type":"json","path":"frontend/tracker/package.json","jsonpath":"$.version"},{"type":"generic","path":"frontend/dashboard/src/tracker/version.ts"},{"type":"yaml","path":"charts/hitkeep/Chart.yaml","jsonpath":"$.version"},{"type":"yaml","path":"charts/hitkeep/Chart.yaml","jsonpath":"$.appVersion"},{"type":"generic","path":"charts/hitkeep/README.md"}]}}}`
 }
 
 func writeFixtureFile(t *testing.T, root, name, contents string) {

--- a/internal/devtool/release_ordering_test.go
+++ b/internal/devtool/release_ordering_test.go
@@ -102,7 +102,8 @@ func TestValidateReleaseWorkflowGraph(t *testing.T) {
           npm view @hitkeep/tracker dist.integrity
       - name: Promote tracker latest dist-tag
       - name: Promote immutable image to mutable tags
-      - name: Publish draft GitHub release
+      - name: Promote GitHub release
+        run: gh release edit "$TAG" --prerelease=false --latest
   sync-docs-release:
     needs:
       - finalize-release
@@ -180,9 +181,14 @@ func TestValidateReleaseWorkflowGraph(t *testing.T) {
 		t.Fatal("validateReleaseWorkflowGraph() accepted a finalizer without the verified tracker artifact")
 	}
 
-	earlyPublish := strings.Replace(workflow, "      - name: Promote immutable image to mutable tags\n      - name: Publish draft GitHub release", "      - name: Publish draft GitHub release\n      - name: Promote immutable image to mutable tags", 1)
+	earlyPublish := strings.Replace(workflow, "      - name: Promote immutable image to mutable tags\n      - name: Promote GitHub release", "      - name: Promote GitHub release\n      - name: Promote immutable image to mutable tags", 1)
 	if err := validateReleaseWorkflowGraph([]byte(earlyPublish)); err == nil {
 		t.Fatal("validateReleaseWorkflowGraph() accepted a draft publication before mutable tag promotion")
+	}
+
+	missingPrereleasePromotion := strings.Replace(workflow, "--prerelease=false", "--draft=false", 1)
+	if err := validateReleaseWorkflowGraph([]byte(missingPrereleasePromotion)); err == nil {
+		t.Fatal("validateReleaseWorkflowGraph() accepted a finalizer that does not promote the prerelease")
 	}
 
 	latestBeforeCandidate := strings.Replace(workflow, "      - name: Publish immutable tracker candidate", "      - name: candidate-placeholder", 1)
@@ -192,7 +198,7 @@ func TestValidateReleaseWorkflowGraph(t *testing.T) {
 		t.Fatal("validateReleaseWorkflowGraph() accepted a latest dist-tag promotion before retry-safe candidate publication")
 	}
 
-	patFinalizer := strings.Replace(workflow, "      - name: Publish draft GitHub release", "      - name: Publish draft GitHub release\n        env:\n          GH_TOKEN: ${{ secrets.GHT }}", 1)
+	patFinalizer := strings.Replace(workflow, "      - name: Promote GitHub release", "      - name: Promote GitHub release\n        env:\n          GH_TOKEN: ${{ secrets.GHT }}", 1)
 	if err := validateReleaseWorkflowGraph([]byte(patFinalizer)); err == nil {
 		t.Fatal("validateReleaseWorkflowGraph() accepted secrets.GHT in the finalizer")
 	}

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -1,5 +1,6 @@
 {
-  "draft": true,
+  "draft": false,
+  "prerelease": true,
   "packages": {
     ".": {
       "changelog-path": "CHANGELOG.md",
@@ -46,8 +47,8 @@
       ],
       "bump-minor-pre-major": false,
       "bump-patch-for-minor-pre-major": false,
-      "draft": true,
-      "prerelease": false
+      "draft": false,
+      "prerelease": true
     }
   },
   "$schema": "https://raw.githubusercontent.com/googleapis/release-please/main/schemas/config.json"


### PR DESCRIPTION
## Summary
- let Release Please create an immutable prerelease tag before artifact builds
- promote the candidate to latest/stable only after every release gate passes
- keep generated configuration inputs runner-local so tagged GoReleaser builds remain clean
- enforce the release contracts with focused negative tests

## Proof
- affected Go race suite
- format and Go migration checks
- golangci-lint, go vet, Staticcheck
- GoReleaser config check
- developer docs and workflow security checks

Recovery for the unpublished v2.13.13 draft remains separate until this repair is merged.