### PR TITLE
fix(release): make draft candidates retry-safe

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -121,7 +121,8 @@ jobs:
             echo "invalid candidate image digest" >&2
             exit 1
           fi
-          candidate="ghcr.io/${GITHUB_REPOSITORY}@${CANDIDATE_DIGEST}"
+          repository="${GITHUB_REPOSITORY,,}"
+          candidate="ghcr.io/${repository}@${CANDIDATE_DIGEST}"
           docker pull "$candidate"
           platform="linux/$(docker image inspect "$candidate" --format '{{.Architecture}}')"
           previous_version="$(jq -r '.supported_upgrade_floor' "$manifest")"
@@ -310,7 +311,11 @@ jobs:
         run: npm ci --no-audit --no-fund
 
       - name: Build and verify package
-        run: ./hk qa pr --gate tracker-package
+        shell: bash
+        run: |
+          set -euo pipefail
+          plan_id="$(./hk qa plan pr --output json | jq -r '.data.plan_id')"
+          ./hk qa pr --plan-id "$plan_id" --gate tracker-package
 
       - name: Verify release version matches package
         env:
@@ -549,8 +554,9 @@ jobs:
             exit 1
           fi
           IFS=. read -r major minor _ <<< "$VERSION"
-          source="ghcr.io/${GITHUB_REPOSITORY}@${CANDIDATE_DIGEST}"
-          for base in "ghcr.io/${GITHUB_REPOSITORY}" "${DOCKERHUB_USERNAME}/hitkeep"; do
+          repository="${GITHUB_REPOSITORY,,}"
+          source="ghcr.io/${repository}@${CANDIDATE_DIGEST}"
+          for base in "ghcr.io/${repository}" "${DOCKERHUB_USERNAME}/hitkeep"; do
             docker buildx imagetools create \
               --tag "${base}:latest" \
               --tag "${base}:${major}" \
@@ -562,7 +568,7 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
           TAG: ${{ needs.release-please.outputs.tag_name }}
-        run: gh release edit "$TAG" --prerelease=false --latest
+        run: gh release edit "$TAG" --draft=false --latest
 
   sync-docs-release:
     name: Publish release and configuration metadata to docs

--- a/internal/devtool/docs.go
+++ b/internal/devtool/docs.go
@@ -24,9 +24,10 @@ var dockerfileVolumePattern = regexp.MustCompile(`(?m)^\s*VOLUME\s+(.+)$`)
 var dockerfileQuotedPathPattern = regexp.MustCompile(`"([^"]+)"`)
 
 type releasePleaseConfig struct {
-	Draft      bool `json:"draft"`
-	Prerelease bool `json:"prerelease"`
-	Packages   map[string]struct {
+	Draft            bool `json:"draft"`
+	Prerelease       bool `json:"prerelease"`
+	ForceTagCreation bool `json:"force-tag-creation"`
+	Packages         map[string]struct {
 		Draft      *bool                    `json:"draft"`
 		Prerelease *bool                    `json:"prerelease"`
 		ExtraFiles []releasePleaseExtraFile `json:"extra-files"`
@@ -141,6 +142,8 @@ func validateReleaseWorkflowGraph(raw []byte) error {
 	}
 	for _, step := range workflow.Jobs["upgrade-from-supported-floor"].Steps {
 		if strings.Contains(step.Run, "tests/fixtures/release-fixtures.json") &&
+			strings.Contains(step.Run, `repository="${GITHUB_REPOSITORY,,}"`) &&
+			strings.Contains(step.Run, `candidate="ghcr.io/${repository}@${CANDIDATE_DIGEST}"`) &&
 			strings.Contains(step.Run, "previous_version") {
 			fixtureResolved = true
 		}
@@ -163,8 +166,16 @@ func validateReleaseWorkflowGraph(raw []byte) error {
 	}
 
 	trackerArtifact := map[string]bool{}
+	trackerPlanBound := false
 	for _, step := range workflow.Jobs["verify-tracker-package"].Steps {
 		trackerArtifact[step.Name] = true
+		if strings.Contains(step.Run, `plan_id="$(./hk qa plan pr --output json | jq -r '.data.plan_id')"`) &&
+			strings.Contains(step.Run, `./hk qa pr --plan-id "$plan_id" --gate tracker-package`) {
+			trackerPlanBound = true
+		}
+	}
+	if !trackerPlanBound {
+		return fmt.Errorf("release workflow verify-tracker-package must run tracker QA with its persisted plan ID")
 	}
 	if !trackerArtifact["Pack verified tracker artifact"] || !trackerArtifact["Upload verified tracker artifact"] {
 		return fmt.Errorf("release workflow verify-tracker-package must pack and upload the verified tracker artifact")
@@ -187,14 +198,14 @@ func validateReleaseWorkflowGraph(raw []byte) error {
 	if !trackerDownload || !trackerPublish {
 		return fmt.Errorf("release workflow finalizer must publish the verified tracker artifact with npm integrity verification")
 	}
-	prereleasePromotion := false
+	draftPublication := false
 	for _, step := range finalizer.Steps {
-		if step.Name == "Promote GitHub release" && strings.Contains(step.Run, `gh release edit "$TAG" --prerelease=false --latest`) {
-			prereleasePromotion = true
+		if step.Name == "Promote GitHub release" && strings.Contains(step.Run, `gh release edit "$TAG" --draft=false --latest`) {
+			draftPublication = true
 		}
 	}
-	if !prereleasePromotion {
-		return fmt.Errorf("release workflow finalizer must promote the prerelease to latest")
+	if !draftPublication {
+		return fmt.Errorf("release workflow finalizer must publish the draft as latest")
 	}
 	for _, step := range finalizer.Steps {
 		for _, values := range []map[string]string{step.Env, step.With} {
@@ -711,15 +722,18 @@ func validateReleaseMetadata(root string) error {
 	if rootPackageConfig.Draft != nil {
 		effectiveDraft = *rootPackageConfig.Draft
 	}
-	if effectiveDraft {
-		return fmt.Errorf("release-please-config.json effective packages['.'].draft must be false")
+	if !effectiveDraft {
+		return fmt.Errorf("release-please-config.json effective packages['.'].draft must be true")
 	}
 	effectivePrerelease := config.Prerelease
 	if rootPackageConfig.Prerelease != nil {
 		effectivePrerelease = *rootPackageConfig.Prerelease
 	}
-	if !effectivePrerelease {
-		return fmt.Errorf("release-please-config.json effective packages['.'].prerelease must be true")
+	if effectivePrerelease {
+		return fmt.Errorf("release-please-config.json effective packages['.'].prerelease must be false")
+	}
+	if !config.ForceTagCreation {
+		return fmt.Errorf("release-please-config.json force-tag-creation must be true")
 	}
 	expectedFiles := []releasePleaseExtraFile{
 		{Type: "json", Path: "server.json", JSONPath: "$.version"},

--- a/internal/devtool/docs_test.go
+++ b/internal/devtool/docs_test.go
@@ -64,12 +64,22 @@ func TestValidateReleaseMetadata(t *testing.T) {
 		}
 	})
 
-	t.Run("draft candidate is rejected", func(t *testing.T) {
+	t.Run("published candidate is rejected", func(t *testing.T) {
 		root := releaseMetadataFixture(t)
-		config := strings.Replace(fixtureReleasePleaseConfig(), `".":{"draft":false`, `".":{"draft":true`, 1)
+		config := strings.Replace(fixtureReleasePleaseConfig(), `".":{"draft":true`, `".":{"draft":false`, 1)
 		writeFixtureFile(t, root, "release-please-config.json", config)
 		err := validateReleaseMetadata(root)
-		if err == nil || !strings.Contains(err.Error(), "effective packages['.'].draft must be false") {
+		if err == nil || !strings.Contains(err.Error(), "effective packages['.'].draft must be true") {
+			t.Fatalf("unexpected error: %v", err)
+		}
+	})
+
+	t.Run("missing forced tag creation", func(t *testing.T) {
+		root := releaseMetadataFixture(t)
+		config := strings.Replace(fixtureReleasePleaseConfig(), `"force-tag-creation":true`, `"force-tag-creation":false`, 1)
+		writeFixtureFile(t, root, "release-please-config.json", config)
+		err := validateReleaseMetadata(root)
+		if err == nil || !strings.Contains(err.Error(), "force-tag-creation must be true") {
 			t.Fatalf("unexpected error: %v", err)
 		}
 	})
@@ -326,6 +336,8 @@ jobs:
           CANDIDATE_DIGEST: ${{ needs.build-release.outputs.image_digest }}
         run: |
           manifest="tests/fixtures/release-fixtures.json"
+          repository="${GITHUB_REPOSITORY,,}"
+          candidate="ghcr.io/${repository}@${CANDIDATE_DIGEST}"
           previous_version="2.12.0"
       - name: Smoke Docker upgrade from supported floor
         env:
@@ -347,6 +359,10 @@ jobs:
   verify-tracker-package:
     needs: build-release
     steps:
+      - name: Build and verify package
+        run: |
+          plan_id="$(./hk qa plan pr --output json | jq -r '.data.plan_id')"
+          ./hk qa pr --plan-id "$plan_id" --gate tracker-package
       - name: Pack verified tracker artifact
         run: npm pack --json
       - name: Upload verified tracker artifact
@@ -397,7 +413,7 @@ jobs:
       - name: Promote tracker latest dist-tag
       - name: Promote immutable image to mutable tags
       - name: Promote GitHub release
-        run: gh release edit "$TAG" --prerelease=false --latest
+        run: gh release edit "$TAG" --draft=false --latest
   sync-docs-release:
     needs:
       - finalize-release
@@ -429,7 +445,7 @@ jobs: {}
 }
 
 func fixtureReleasePleaseConfig() string {
-	return `{"draft":false,"prerelease":true,"packages":{".":{"draft":false,"prerelease":true,"extra-files":[{"type":"json","path":"server.json","jsonpath":"$.version"},{"type":"json","path":"frontend/dashboard/package.json","jsonpath":"$.version"},{"type":"json","path":"frontend/dashboard/package-lock.json","jsonpath":"$['packages']['']['version']"},{"type":"json","path":"frontend/tracker/package.json","jsonpath":"$.version"},{"type":"generic","path":"frontend/dashboard/src/tracker/version.ts"},{"type":"yaml","path":"charts/hitkeep/Chart.yaml","jsonpath":"$.version"},{"type":"yaml","path":"charts/hitkeep/Chart.yaml","jsonpath":"$.appVersion"},{"type":"generic","path":"charts/hitkeep/README.md"}]}}}`
+	return `{"draft":true,"prerelease":false,"force-tag-creation":true,"packages":{".":{"draft":true,"prerelease":false,"extra-files":[{"type":"json","path":"server.json","jsonpath":"$.version"},{"type":"json","path":"frontend/dashboard/package.json","jsonpath":"$.version"},{"type":"json","path":"frontend/dashboard/package-lock.json","jsonpath":"$['packages']['']['version']"},{"type":"json","path":"frontend/tracker/package.json","jsonpath":"$.version"},{"type":"generic","path":"frontend/dashboard/src/tracker/version.ts"},{"type":"yaml","path":"charts/hitkeep/Chart.yaml","jsonpath":"$.version"},{"type":"yaml","path":"charts/hitkeep/Chart.yaml","jsonpath":"$.appVersion"},{"type":"generic","path":"charts/hitkeep/README.md"}]}}}`
 }
 
 func writeFixtureFile(t *testing.T, root, name, contents string) {

--- a/internal/devtool/release_ordering_test.go
+++ b/internal/devtool/release_ordering_test.go
@@ -30,6 +30,8 @@ func TestValidateReleaseWorkflowGraph(t *testing.T) {
           CANDIDATE_DIGEST: ${{ needs.build-release.outputs.image_digest }}
         run: |
           manifest="tests/fixtures/release-fixtures.json"
+          repository="${GITHUB_REPOSITORY,,}"
+          candidate="ghcr.io/${repository}@${CANDIDATE_DIGEST}"
           previous_version="2.12.0"
       - name: Smoke Docker upgrade from supported floor
         env:
@@ -51,6 +53,10 @@ func TestValidateReleaseWorkflowGraph(t *testing.T) {
   verify-tracker-package:
     needs: build-release
     steps:
+      - name: Build and verify package
+        run: |
+          plan_id="$(./hk qa plan pr --output json | jq -r '.data.plan_id')"
+          ./hk qa pr --plan-id "$plan_id" --gate tracker-package
       - name: Pack verified tracker artifact
         run: npm pack --json
       - name: Upload verified tracker artifact
@@ -103,7 +109,7 @@ func TestValidateReleaseWorkflowGraph(t *testing.T) {
       - name: Promote tracker latest dist-tag
       - name: Promote immutable image to mutable tags
       - name: Promote GitHub release
-        run: gh release edit "$TAG" --prerelease=false --latest
+        run: gh release edit "$TAG" --draft=false --latest
   sync-docs-release:
     needs:
       - finalize-release
@@ -186,9 +192,19 @@ func TestValidateReleaseWorkflowGraph(t *testing.T) {
 		t.Fatal("validateReleaseWorkflowGraph() accepted a draft publication before mutable tag promotion")
 	}
 
-	missingPrereleasePromotion := strings.Replace(workflow, "--prerelease=false", "--draft=false", 1)
-	if err := validateReleaseWorkflowGraph([]byte(missingPrereleasePromotion)); err == nil {
-		t.Fatal("validateReleaseWorkflowGraph() accepted a finalizer that does not promote the prerelease")
+	missingDraftPublication := strings.Replace(workflow, "--draft=false", "--prerelease=false", 1)
+	if err := validateReleaseWorkflowGraph([]byte(missingDraftPublication)); err == nil {
+		t.Fatal("validateReleaseWorkflowGraph() accepted a finalizer that does not publish the draft")
+	}
+
+	unnormalizedRepository := strings.Replace(workflow, `repository="${GITHUB_REPOSITORY,,}"`, `repository="$GITHUB_REPOSITORY"`, 1)
+	if err := validateReleaseWorkflowGraph([]byte(unnormalizedRepository)); err == nil {
+		t.Fatal("validateReleaseWorkflowGraph() accepted a candidate image repository without lowercase normalization")
+	}
+
+	missingTrackerPlan := strings.Replace(workflow, `--plan-id "$plan_id"`, "", 1)
+	if err := validateReleaseWorkflowGraph([]byte(missingTrackerPlan)); err == nil {
+		t.Fatal("validateReleaseWorkflowGraph() accepted tracker QA without its persisted plan ID")
 	}
 
 	latestBeforeCandidate := strings.Replace(workflow, "      - name: Publish immutable tracker candidate", "      - name: candidate-placeholder", 1)

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -1,6 +1,7 @@
 {
-  "draft": false,
-  "prerelease": true,
+  "draft": true,
+  "prerelease": false,
+  "force-tag-creation": true,
   "packages": {
     ".": {
       "changelog-path": "CHANGELOG.md",
@@ -47,8 +48,8 @@
       ],
       "bump-minor-pre-major": false,
       "bump-patch-for-minor-pre-major": false,
-      "draft": false,
-      "prerelease": true
+      "draft": true,
+      "prerelease": false
     }
   },
   "$schema": "https://raw.githubusercontent.com/googleapis/release-please/main/schemas/config.json"


### PR DESCRIPTION
## Summary
- create draft releases with an immediate tag
- normalize GHCR repository names and bind tracker QA to a persisted plan
- publish the draft only after release gates succeed

## Local validation
- `go test -race ./internal/devtool`
- hk PR plan `6d49b8ade35cc7c1a7b61589`: `developer-docs`, `go-fix`, `go-format`, `go-lint`, `go-staticcheck`, `go-vet`, `zizmor` passed

## CI quota
Artifact-producing Homebrew, cross-CGO, and Helm validation is unchanged and already passed for the prior candidate. Keep only the minimal workflow-security check for this PR.