### PR TITLE
fix(release): parse canonical npm pack output

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -334,7 +334,7 @@ jobs:
         run: |
           set -euo pipefail
           metadata="$(npm pack --json)"
-          tarball="$(jq -r '.[0].filename' <<< "$metadata")"
+          tarball="$(jq -r 'to_entries | first | .value.filename' <<< "$metadata")"
           test -n "$tarball"
           test -f "$tarball"
           mv "$tarball" verified-tracker.tgz

--- a/internal/devtool/docs.go
+++ b/internal/devtool/docs.go
@@ -168,7 +168,14 @@ func validateReleaseWorkflowGraph(raw []byte) error {
 	trackerArtifact := map[string]bool{}
 	trackerPlanBound := false
 	for _, step := range workflow.Jobs["verify-tracker-package"].Steps {
-		trackerArtifact[step.Name] = true
+		if step.Name == "Pack verified tracker artifact" &&
+			strings.Contains(step.Run, "npm pack --json") &&
+			strings.Contains(step.Run, "to_entries | first | .value.filename") {
+			trackerArtifact[step.Name] = true
+		}
+		if step.Name == "Upload verified tracker artifact" {
+			trackerArtifact[step.Name] = true
+		}
 		if strings.Contains(step.Run, `plan_id="$(./hk qa plan pr --output json | jq -r '.data.plan_id')"`) &&
 			strings.Contains(step.Run, `./hk qa pr --plan-id "$plan_id" --gate tracker-package`) {
 			trackerPlanBound = true

--- a/internal/devtool/docs_test.go
+++ b/internal/devtool/docs_test.go
@@ -364,7 +364,9 @@ jobs:
           plan_id="$(./hk qa plan pr --output json | jq -r '.data.plan_id')"
           ./hk qa pr --plan-id "$plan_id" --gate tracker-package
       - name: Pack verified tracker artifact
-        run: npm pack --json
+        run: |
+          metadata="$(npm pack --json)"
+          tarball="$(jq -r 'to_entries | first | .value.filename' <<< "$metadata")"
       - name: Upload verified tracker artifact
   docs-attestation:
     needs:

--- a/internal/devtool/release_ordering_test.go
+++ b/internal/devtool/release_ordering_test.go
@@ -58,7 +58,9 @@ func TestValidateReleaseWorkflowGraph(t *testing.T) {
           plan_id="$(./hk qa plan pr --output json | jq -r '.data.plan_id')"
           ./hk qa pr --plan-id "$plan_id" --gate tracker-package
       - name: Pack verified tracker artifact
-        run: npm pack --json
+        run: |
+          metadata="$(npm pack --json)"
+          tarball="$(jq -r 'to_entries | first | .value.filename' <<< "$metadata")"
       - name: Upload verified tracker artifact
   link-release-blog:
     needs: release-please
@@ -205,6 +207,11 @@ func TestValidateReleaseWorkflowGraph(t *testing.T) {
 	missingTrackerPlan := strings.Replace(workflow, `--plan-id "$plan_id"`, "", 1)
 	if err := validateReleaseWorkflowGraph([]byte(missingTrackerPlan)); err == nil {
 		t.Fatal("validateReleaseWorkflowGraph() accepted tracker QA without its persisted plan ID")
+	}
+
+	arrayOnlyPackMetadata := strings.Replace(workflow, "to_entries | first | .value.filename", ".[0].filename", 1)
+	if err := validateReleaseWorkflowGraph([]byte(arrayOnlyPackMetadata)); err == nil {
+		t.Fatal("validateReleaseWorkflowGraph() accepted the obsolete array-only npm pack metadata parser")
 	}
 
 	latestBeforeCandidate := strings.Replace(workflow, "      - name: Publish immutable tracker candidate", "      - name: candidate-placeholder", 1)


### PR DESCRIPTION
## Summary
- parse canonical npm 11 `npm pack --json` object output
- reject the obsolete array-only parser in the release workflow contract

## Evidence
- reproduced locally with canonical npm output keyed by `@hitkeep/tracker`
- `go test -race ./appurl ./cmd ./cmd/hitkeep ./cmd/hk ./internal/devtool`
- hk PR plan `8228811e9ef847507b87abdb`: static release/Go/zizmor gates passed

## CI quota
Keep only zizmor; this is a one-expression workflow repair and all `2.13.15` build/upgrade/Helm jobs are already green.