### PR TITLE
fix(helm): defer liveness during upgrades

### DIFF
--- a/charts/hitkeep/templates/statefulset.yaml
+++ b/charts/hitkeep/templates/statefulset.yaml
@@ -145,6 +145,13 @@ spec:
           args:
             {{- toYaml .Values.extraArgs | nindent 12 }}
           {{- end }}
+          startupProbe:
+            httpGet:
+              path: /healthz
+              port: http
+            periodSeconds: 5
+            timeoutSeconds: 3
+            failureThreshold: 48
           livenessProbe:
             httpGet:
               path: /healthz

--- a/internal/devtool/helm_upgrade_test.go
+++ b/internal/devtool/helm_upgrade_test.go
@@ -85,6 +85,23 @@ func TestHelmChartSupportsDigestPinnedSmokeImages(t *testing.T) {
 	}
 }
 
+func TestHelmChartDefersLivenessDuringUpgradeStartup(t *testing.T) {
+	raw, err := os.ReadFile(filepath.Join("..", "..", "charts", "hitkeep", "templates", "statefulset.yaml"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, required := range []string{
+		"startupProbe:",
+		"path: /healthz",
+		"periodSeconds: 5",
+		"failureThreshold: 48",
+	} {
+		if !bytes.Contains(raw, []byte(required)) {
+			t.Fatalf("chart startup probe is missing contract %q", required)
+		}
+	}
+}
+
 func TestHelmTemplateRendersImmutableReferencesForLegacyAndCandidateCharts(t *testing.T) {
 	if os.Getenv("HITKEEP_HELM_TEMPLATE_CONTRACT") != "1" {
 		t.Skip("set HITKEEP_HELM_TEMPLATE_CONTRACT=1 to render the immutable supported-floor chart fixture")


### PR DESCRIPTION
## Summary
- add a native Kubernetes startup probe for long one-time migrations and compaction
- retain existing readiness and steady-state liveness behavior
- add a focused chart contract test

## Failure evidence
Both `2.13.16` Helm attempts completed migrations, then liveness restarted the pod during shared database compaction. Docker, Compose, tracker, binaries, images, archives, and Helm publication are green.

## Local validation
- `go test -race ./internal/devtool`
- `helm template hitkeep charts/hitkeep`
- `helm lint charts/hitkeep`
- hk PR plan `1b5d2245dbaac56b1aaa234c`: static release/Go/zizmor gates passed

## CI quota
Keep only zizmor. Do not run snapshot, broad CI, Govulncheck, or release-validation; the release run itself is the required end-to-end proof.