### PR TITLE
fix(release): keep migration acceptance manual

### DIFF
--- a/.github/workflows/default-tenant-migration-acceptance.yml
+++ b/.github/workflows/default-tenant-migration-acceptance.yml
@@ -1,7 +1,6 @@
 name: Default Tenant Migration Acceptance
 
 on:
-  workflow_call:
   workflow_dispatch:
 
 concurrency:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -53,16 +53,6 @@ jobs:
       DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
       DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}
 
-  migration-interruption:
-    name: Verify migration interruption safety
-    needs:
-      - release-please
-      - build-release
-    if: ${{ needs.release-please.outputs.release_created == 'true' && needs.build-release.result == 'success' }}
-    uses: ./.github/workflows/default-tenant-migration-acceptance.yml
-    permissions:
-      contents: read
-
   upgrade-from-supported-floor:
     name: ${{ matrix.name }}
     needs:
@@ -357,11 +347,10 @@ jobs:
     needs:
       - release-please
       - build-release
-      - migration-interruption
       - upgrade-from-supported-floor
       - publish-helm
       - verify-tracker-package
-    if: ${{ needs.release-please.outputs.release_created == 'true' && needs.build-release.result == 'success' && needs.migration-interruption.result == 'success' && needs.upgrade-from-supported-floor.result == 'success' && needs.publish-helm.result == 'success' && needs.verify-tracker-package.result == 'success' }}
+    if: ${{ needs.release-please.outputs.release_created == 'true' && needs.build-release.result == 'success' && needs.upgrade-from-supported-floor.result == 'success' && needs.publish-helm.result == 'success' && needs.verify-tracker-package.result == 'success' }}
     runs-on: ubuntu-latest
     timeout-minutes: 30
     permissions:
@@ -470,12 +459,11 @@ jobs:
     needs:
       - release-please
       - build-release
-      - migration-interruption
       - upgrade-from-supported-floor
       - publish-helm
       - verify-tracker-package
       - docs-attestation
-    if: ${{ needs.release-please.outputs.release_created == 'true' && needs.build-release.result == 'success' && needs.migration-interruption.result == 'success' && needs.upgrade-from-supported-floor.result == 'success' && needs.publish-helm.result == 'success' && needs.verify-tracker-package.result == 'success' && needs.docs-attestation.result == 'success' }}
+    if: ${{ needs.release-please.outputs.release_created == 'true' && needs.build-release.result == 'success' && needs.upgrade-from-supported-floor.result == 'success' && needs.publish-helm.result == 'success' && needs.verify-tracker-package.result == 'success' && needs.docs-attestation.result == 'success' }}
     runs-on: ubuntu-latest
     permissions:
       contents: write

--- a/internal/devtool/docs.go
+++ b/internal/devtool/docs.go
@@ -89,12 +89,21 @@ func validateDefaultTenantMigrationAcceptanceWorkflow(raw []byte) error {
 	if err := yaml.Unmarshal(raw, &workflow); err != nil {
 		return fmt.Errorf("decode default-tenant migration acceptance workflow: %w", err)
 	}
+	manual := false
 	for index := 0; index+1 < len(workflow.On.Content); index += 2 {
-		if workflow.On.Content[index].Value == "workflow_call" {
-			return nil
+		switch event := workflow.On.Content[index].Value; event {
+		case "workflow_dispatch":
+			manual = true
+		case "workflow_call":
+			return fmt.Errorf("default-tenant migration acceptance workflow must not support workflow_call")
+		default:
+			return fmt.Errorf("default-tenant migration acceptance workflow must not support %s", event)
 		}
 	}
-	return fmt.Errorf("default-tenant migration acceptance workflow must support workflow_call")
+	if !manual {
+		return fmt.Errorf("default-tenant migration acceptance workflow must support workflow_dispatch")
+	}
+	return nil
 }
 
 func validateReleaseWorkflowGraph(raw []byte) error {
@@ -104,12 +113,11 @@ func validateReleaseWorkflowGraph(raw []byte) error {
 	}
 	for job, required := range map[string][]string{
 		"build-release":                {"release-please"},
-		"migration-interruption":       {"release-please", "build-release"},
 		"upgrade-from-supported-floor": {"build-release"},
 		"publish-helm":                 {"build-release"},
 		"verify-tracker-package":       {"build-release"},
-		"docs-attestation":             {"release-please", "build-release", "migration-interruption", "upgrade-from-supported-floor", "publish-helm", "verify-tracker-package"},
-		"finalize-release":             {"release-please", "build-release", "migration-interruption", "upgrade-from-supported-floor", "publish-helm", "verify-tracker-package", "docs-attestation"},
+		"docs-attestation":             {"release-please", "build-release", "upgrade-from-supported-floor", "publish-helm", "verify-tracker-package"},
+		"finalize-release":             {"release-please", "build-release", "upgrade-from-supported-floor", "publish-helm", "verify-tracker-package", "docs-attestation"},
 		"sync-docs-release":            {"finalize-release"},
 		"deploy-cloud":                 {"finalize-release"},
 	} {
@@ -123,15 +131,10 @@ func validateReleaseWorkflowGraph(raw []byte) error {
 			}
 		}
 	}
-	migrationInterruption := workflow.Jobs["migration-interruption"]
-	if migrationInterruption.Uses != "./.github/workflows/default-tenant-migration-acceptance.yml" {
-		return fmt.Errorf("release workflow migration-interruption must call the default-tenant migration acceptance workflow")
-	}
-	if !strings.Contains(migrationInterruption.If, "needs.release-please.outputs.release_created == 'true'") {
-		return fmt.Errorf("release workflow migration-interruption must be gated on release creation")
-	}
-	if !strings.Contains(migrationInterruption.If, "needs.build-release.result == 'success'") {
-		return fmt.Errorf("release workflow migration-interruption must be gated on a successful release build")
+	for job, definition := range workflow.Jobs {
+		if definition.Uses == "./.github/workflows/default-tenant-migration-acceptance.yml" {
+			return fmt.Errorf("release workflow job %s must not call the manual default-tenant migration acceptance workflow", job)
+		}
 	}
 	fixtureResolved := false
 	upgradeSmokes := map[string]bool{}

--- a/internal/devtool/docs_test.go
+++ b/internal/devtool/docs_test.go
@@ -26,11 +26,11 @@ func TestValidateReleaseMetadata(t *testing.T) {
 		}
 	})
 
-	t.Run("migration workflow is not reusable", func(t *testing.T) {
+	t.Run("reusable migration workflow is rejected", func(t *testing.T) {
 		root := releaseMetadataFixture(t)
-		writeFixtureFile(t, root, ".github/workflows/default-tenant-migration-acceptance.yml", "on:\n  workflow_dispatch:\njobs: {}\n")
+		writeFixtureFile(t, root, ".github/workflows/default-tenant-migration-acceptance.yml", "on:\n  workflow_call:\njobs: {}\n")
 		err := validateReleaseMetadata(root)
-		if err == nil || !strings.Contains(err.Error(), "must support workflow_call") {
+		if err == nil || !strings.Contains(err.Error(), "must not support workflow_call") {
 			t.Fatalf("unexpected error: %v", err)
 		}
 	})
@@ -315,12 +315,6 @@ jobs:
   release-please: {}
   build-release:
     needs: release-please
-  migration-interruption:
-    needs:
-      - release-please
-      - build-release
-    if: ${{ needs.release-please.outputs.release_created == 'true' && needs.build-release.result == 'success' }}
-    uses: ./.github/workflows/default-tenant-migration-acceptance.yml
   upgrade-from-supported-floor:
     needs: build-release
     strategy:
@@ -372,7 +366,6 @@ jobs:
     needs:
       - release-please
       - build-release
-      - migration-interruption
       - upgrade-from-supported-floor
       - publish-helm
       - verify-tracker-package
@@ -400,7 +393,6 @@ jobs:
     needs:
       - release-please
       - build-release
-      - migration-interruption
       - upgrade-from-supported-floor
       - publish-helm
       - verify-tracker-package
@@ -440,7 +432,7 @@ jobs:
     needs: finalize-release
 `)
 	writeFixtureFile(t, root, ".github/workflows/default-tenant-migration-acceptance.yml", `on:
-  workflow_call:
+  workflow_dispatch:
 jobs: {}
 `)
 	return root

--- a/internal/devtool/release_migration_interruption_test.go
+++ b/internal/devtool/release_migration_interruption_test.go
@@ -6,45 +6,33 @@ import (
 	"testing"
 )
 
-func TestValidateDefaultTenantMigrationAcceptanceWorkflowRequiresCallableTrigger(t *testing.T) {
-	raw, err := os.ReadFile("../../.github/workflows/default-tenant-migration-acceptance.yml")
-	if err != nil {
-		t.Fatal(err)
+func TestValidateDefaultTenantMigrationAcceptanceWorkflowIsManualOnly(t *testing.T) {
+	if err := validateDefaultTenantMigrationAcceptanceWorkflow([]byte("on:\n  workflow_dispatch:\n")); err != nil {
+		t.Fatalf("validateDefaultTenantMigrationAcceptanceWorkflow() error = %v", err)
 	}
-	if err := validateDefaultTenantMigrationAcceptanceWorkflow([]byte(strings.Replace(string(raw), "workflow_call:", "# workflow_call:", 1))); err == nil {
-		t.Fatal("validateDefaultTenantMigrationAcceptanceWorkflow() error = nil, want callable trigger error")
+	if err := validateDefaultTenantMigrationAcceptanceWorkflow([]byte("on:\n  workflow_call:\n")); err == nil {
+		t.Fatal("validateDefaultTenantMigrationAcceptanceWorkflow() error = nil, want reusable trigger error")
+	}
+	if err := validateDefaultTenantMigrationAcceptanceWorkflow([]byte("on:\n  workflow_dispatch:\n  push:\n")); err == nil {
+		t.Fatal("validateDefaultTenantMigrationAcceptanceWorkflow() error = nil, want automatic trigger error")
 	}
 }
 
-func TestValidateReleaseWorkflowGraphRequiresMigrationInterruptionGate(t *testing.T) {
+func TestValidateReleaseWorkflowGraphRejectsMigrationInterruptionGate(t *testing.T) {
 	raw, err := os.ReadFile("../../.github/workflows/release.yml")
 	if err != nil {
 		t.Fatal(err)
 	}
+	workflow := strings.Replace(string(raw), "\n  upgrade-from-supported-floor:\n", `
+  manual-migration-check:
+    needs:
+      - release-please
+      - build-release
+    uses: ./.github/workflows/default-tenant-migration-acceptance.yml
 
-	tests := []struct {
-		name     string
-		workflow string
-	}{
-		{
-			name:     "missing release job",
-			workflow: strings.Replace(string(raw), "migration-interruption:", "# migration-interruption:", 1),
-		},
-		{
-			name: "missing finalizer dependency",
-			workflow: func() string {
-				const dependency = "\n      - migration-interruption\n"
-				index := strings.LastIndex(string(raw), dependency)
-				return string(raw[:index]) + "\n" + string(raw[index+len(dependency):])
-			}(),
-		},
-	}
-
-	for _, test := range tests {
-		t.Run(test.name, func(t *testing.T) {
-			if err := validateReleaseWorkflowGraph([]byte(test.workflow)); err == nil {
-				t.Fatal("validateReleaseWorkflowGraph() error = nil, want migration-interruption contract error")
-			}
-		})
+  upgrade-from-supported-floor:
+`, 1)
+	if err := validateReleaseWorkflowGraph([]byte(workflow)); err == nil {
+		t.Fatal("validateReleaseWorkflowGraph() error = nil, want manual migration workflow coupling error")
 	}
 }

--- a/internal/devtool/release_ordering_test.go
+++ b/internal/devtool/release_ordering_test.go
@@ -10,12 +10,6 @@ func TestValidateReleaseWorkflowGraph(t *testing.T) {
   release-please: {}
   build-release:
     needs: release-please
-  migration-interruption:
-    needs:
-      - release-please
-      - build-release
-    if: ${{ needs.release-please.outputs.release_created == 'true' && needs.build-release.result == 'success' }}
-    uses: ./.github/workflows/default-tenant-migration-acceptance.yml
   upgrade-from-supported-floor:
     needs: build-release
     strategy:
@@ -68,7 +62,6 @@ func TestValidateReleaseWorkflowGraph(t *testing.T) {
     needs:
       - release-please
       - build-release
-      - migration-interruption
       - upgrade-from-supported-floor
       - publish-helm
       - verify-tracker-package
@@ -96,7 +89,6 @@ func TestValidateReleaseWorkflowGraph(t *testing.T) {
     needs:
       - release-please
       - build-release
-      - migration-interruption
       - upgrade-from-supported-floor
       - publish-helm
       - verify-tracker-package
@@ -147,16 +139,6 @@ func TestValidateReleaseWorkflowGraph(t *testing.T) {
 	missingUpgrade := strings.Replace(workflow, "      - upgrade-from-supported-floor\n", "", 1)
 	if err := validateReleaseWorkflowGraph([]byte(missingUpgrade)); err == nil {
 		t.Fatal("validateReleaseWorkflowGraph() accepted a finalizer that can run before the upgrade smoke")
-	}
-
-	missingMigrationInterruption := strings.Replace(workflow, "      - migration-interruption\n", "", 1)
-	if err := validateReleaseWorkflowGraph([]byte(missingMigrationInterruption)); err == nil {
-		t.Fatal("validateReleaseWorkflowGraph() accepted a finalizer that can run before migration interruption acceptance")
-	}
-
-	missingMigrationGate := strings.Replace(workflow, "  migration-interruption:\n", "  migration-interruption-removed:\n", 1)
-	if err := validateReleaseWorkflowGraph([]byte(missingMigrationGate)); err == nil {
-		t.Fatal("validateReleaseWorkflowGraph() accepted a release without migration interruption acceptance")
 	}
 
 	missingComposeSurface := strings.Replace(workflow, "          - surface: compose\n", "", 1)


### PR DESCRIPTION
## Summary
- keep default-tenant migration acceptance manual-only
- remove the accidental migration gate from normal releases
- enforce both boundaries in release workflow validation

## QA
- `./hk qa complete --plan-id 07d2bcffa311c764b05896b1`
- run `20260901T083907-ddef079d`: passed
- gates: developer-docs, developer-mcp, go-fix, go-format, go-lint, go-race-rest, go-staticcheck, go-vet, goreleaser-check, govulncheck, zizmor