### PR TITLE
fix: publish tracker from local tarball

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -489,7 +489,7 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
-          tarball="tracker-package/verified-tracker.tgz"
+          tarball="./tracker-package/verified-tracker.tgz"
           test -f "$tarball"
           integrity="sha512-$(openssl dgst -sha512 -binary "$tarball" | base64 | tr -d '\n')"
           existing="$(npm view "@hitkeep/tracker@${VERSION}" dist.integrity 2>/dev/null || true)"


### PR DESCRIPTION
npm 12 interprets a slash-containing relative tarball path as a GitHub shorthand. Prefix the verified release artifact with `./` so the finalizer publishes the local package.\n\nLocal proof: `developer-docs` passed in hk run `20260901T093020-5b4be051`.