### PR TITLE
fix: wait for npm package visibility

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches:
       - main
-  workflow_dispatch:
 
 permissions: {}
 
@@ -13,40 +12,7 @@ concurrency:
   cancel-in-progress: false
 
 jobs:
-  recover-tracker-2-13-18:
-    if: ${{ github.event_name == 'workflow_dispatch' }}
-    runs-on: ubuntu-latest
-    permissions:
-      actions: read
-      contents: read
-      id-token: write
-    steps:
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-        with:
-          persist-credentials: false
-      - uses: ./.github/actions/setup-node-npm
-      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
-        with:
-          name: tracker-package-2.13.18
-          path: tracker-package
-          github-token: ${{ github.token }}
-          run-id: 33489007153
-      - name: Publish verified tracker recovery artifact
-        shell: bash
-        run: |
-          set -euo pipefail
-          tarball="./tracker-package/verified-tracker.tgz"
-          test -f "$tarball"
-          integrity="sha512-$(openssl dgst -sha512 -binary "$tarball" | base64 | tr -d '\n')"
-          existing="$(npm view '@hitkeep/tracker@2.13.18' dist.integrity 2>/dev/null || true)"
-          if [[ -z "$existing" ]]; then
-            npm publish "$tarball" --tag release-2.13.18
-            existing="$(npm view '@hitkeep/tracker@2.13.18' dist.integrity)"
-          fi
-          [[ "$existing" == "$integrity" ]]
-
   release-please:
-    if: ${{ github.event_name == 'push' }}
     runs-on: ubuntu-latest
     permissions:
       contents: write
@@ -528,11 +494,12 @@ jobs:
           integrity="sha512-$(openssl dgst -sha512 -binary "$tarball" | base64 | tr -d '\n')"
           existing="$(npm view "@hitkeep/tracker@${VERSION}" dist.integrity 2>/dev/null || true)"
           if [[ -z "$existing" ]]; then
-            if ! npm publish "$tarball" --tag "release-${VERSION}"; then
+            npm publish "$tarball" --tag "release-${VERSION}" || true
+            for attempt in {1..6}; do
               existing="$(npm view "@hitkeep/tracker@${VERSION}" dist.integrity 2>/dev/null || true)"
-            else
-              existing="$(npm view "@hitkeep/tracker@${VERSION}" dist.integrity)"
-            fi
+              [[ -n "$existing" ]] && break
+              sleep 2
+            done
           fi
           if [[ "$existing" != "$integrity" ]]; then
             echo "published @hitkeep/tracker@${VERSION} does not match the verified artifact" >&2


### PR DESCRIPTION
Remove the completed 2.13.18 recovery surface and make the permanent tracker finalizer tolerate npm registry read-after-write propagation while preserving the integrity check.\n\nLocal proof: `developer-docs` passed in hk run `20260901T094243-70d1e712`.