### PR TITLE
Validate Homebrew releases on macOS and Linux

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -132,7 +132,7 @@ jobs:
         with:
           go-version-file: go.mod
           cache-dependency-path: go.sum
-      - uses: ./.github/actions/setup-node-npm
+      - uses: $/.github/actions/setup-node-npm
       - name: Run canonical MCP contract gates
         run: |
           gates="$(./hk ci qa-matrix --profile pr --group production-mcp --output json | jq -r '.data.gate_ids | join(",")')"
@@ -152,7 +152,7 @@ jobs:
         with:
           go-version-file: go.mod
           cache-dependency-path: go.sum
-      - uses: ./.github/actions/setup-node-npm
+      - uses: $/.github/actions/setup-node-npm
       - name: Install dependencies
         working-directory: frontend/dashboard
         run: npm ci --no-audit --no-fund
@@ -175,7 +175,7 @@ jobs:
         with:
           go-version-file: go.mod
           cache-dependency-path: go.sum
-      - uses: ./.github/actions/setup-node-npm
+      - uses: $/.github/actions/setup-node-npm
       - name: Restore Playwright browser cache
         id: playwright-cache
         uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
@@ -211,7 +211,7 @@ jobs:
         with:
           go-version-file: go.mod
           cache-dependency-path: go.sum
-      - uses: ./.github/actions/setup-node-npm
+      - uses: $/.github/actions/setup-node-npm
       - name: Restore Playwright browser cache
         id: playwright-cache
         uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0

--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -95,7 +95,7 @@ jobs:
           go-version-file: go.mod
           cache: false
 
-      - uses: ./.github/actions/setup-node-npm
+      - uses: $/.github/actions/setup-node-npm
 
       - name: Build deterministic dashboard archive
         run: ./hk ci build-dashboard

--- a/.github/workflows/publish-mcp.yml
+++ b/.github/workflows/publish-mcp.yml
@@ -30,7 +30,7 @@ jobs:
           go-version-file: go.mod
           cache: false
 
-      - uses: ./.github/actions/setup-node-npm
+      - uses: $/.github/actions/setup-node-npm
 
       - name: Validate MCP registry metadata
         run: ./hk qa pr --gate mcp-schema

--- a/.github/workflows/release-validation.yml
+++ b/.github/workflows/release-validation.yml
@@ -20,8 +20,15 @@ permissions: {}
 
 jobs:
   homebrew-candidate:
-    if: github.event_name == 'pull_request' && startsWith(github.head_ref, 'release-please--branches--main')
-    runs-on: macos-14
+    if: github.event_name == 'workflow_dispatch' || (github.event_name == 'pull_request' && startsWith(github.head_ref, 'release-please--branches--main'))
+    strategy:
+      fail-fast: false
+      matrix:
+        runner:
+          - macos-14
+          - ubuntu-24.04
+          - ubuntu-24.04-arm
+    runs-on: ${{ matrix.runner }}
     permissions:
       contents: read
     env:
@@ -30,19 +37,47 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
         with:
           persist-credentials: false
-      - name: Prepare candidate formula
-        env:
-          CANDIDATE_SHA: ${{ github.event.pull_request.head.sha }}
+      - name: Configure Homebrew
+        if: runner.os == 'Linux'
         run: |
           set -euo pipefail
-          candidate_version="$(jq -er '."."' .release-please-manifest.json)"
-          [[ "$candidate_version" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]
+          eval "$(/home/linuxbrew/.linuxbrew/bin/brew shellenv)"
+          printf '%s\n' "$HOMEBREW_PREFIX/bin" >> "$GITHUB_PATH"
+          printf 'HOMEBREW_PREFIX=%s\n' "$HOMEBREW_PREFIX" >> "$GITHUB_ENV"
+          printf 'HOMEBREW_CELLAR=%s\n' "$HOMEBREW_CELLAR" >> "$GITHUB_ENV"
+          printf 'HOMEBREW_REPOSITORY=%s\n' "$HOMEBREW_REPOSITORY" >> "$GITHUB_ENV"
+      - name: Install current stable formula
+        run: |
+          set -euo pipefail
+          brew tap PascaleBeier/hitkeep
+          stable_version="$(brew info --json=v2 PascaleBeier/hitkeep/hitkeep | jq -er '.formulae[0].versions.stable')"
+          [[ "$stable_version" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]
+          brew install --build-from-source PascaleBeier/hitkeep/hitkeep
+          test "$(hitkeep --version)" = "$stable_version"
+          printf 'STABLE_VERSION=%s\n' "$stable_version" >> "$GITHUB_ENV"
+      - name: Resolve candidate
+        env:
+          CANDIDATE_SHA: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
+        run: |
+          set -euo pipefail
+          if [[ "$GITHUB_EVENT_NAME" == pull_request ]]; then
+            candidate_version="$(jq -er '."."' .release-please-manifest.json)"
+            [[ "$candidate_version" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]
+          else
+            candidate_version="$(ruby -e 'parts = ARGV[0].split(".").map(&:to_i); puts "#{parts[0]}.#{parts[1]}.#{parts[2] + 1}-validation.#{ARGV[1]}.#{ARGV[2]}"' "$STABLE_VERSION" "$GITHUB_RUN_ID" "$GITHUB_RUN_ATTEMPT")"
+          fi
+          ruby -e 'require "rubygems"; abort unless Gem::Version.new(ARGV[1]) > Gem::Version.new(ARGV[0])' \
+            "$STABLE_VERSION" "$candidate_version"
+          printf 'CANDIDATE_SHA=%s\n' "$CANDIDATE_SHA" >> "$GITHUB_ENV"
+          printf 'CANDIDATE_VERSION=%s\n' "$candidate_version" >> "$GITHUB_ENV"
+      - name: Prepare candidate formula
+        run: |
+          set -euo pipefail
           candidate_url="https://github.com/PascaleBeier/hitkeep/archive/${CANDIDATE_SHA}.tar.gz"
           candidate_checksum="$(curl --fail --silent --show-error --location "$candidate_url" | shasum -a 256 | awk '{print $1}')"
-          brew tap PascaleBeier/hitkeep
           formula="$(brew --repository PascaleBeier/hitkeep)/Formula/hitkeep.rb"
           candidate_formula="$(mktemp)"
-          awk -v version="$candidate_version" -v url="$candidate_url" -v checksum="$candidate_checksum" '
+          awk -v version="$CANDIDATE_VERSION" -v url="$candidate_url" -v checksum="$candidate_checksum" '
             /^  version "/ { print "  version \"" version "\""; versions++; next }
             /^  url "/ {
               if (versions == 0) { print "  version \"" version "\""; versions++ }
@@ -54,14 +89,15 @@ jobs:
           ' "$formula" > "$candidate_formula"
           mv "$candidate_formula" "$formula"
           ruby -c "$formula"
-      - name: Install and test candidate
+      - name: Upgrade to and test candidate
         run: |
           set -euo pipefail
-          candidate_version="$(jq -er '."."' .release-please-manifest.json)"
-          brew install --build-from-source PascaleBeier/hitkeep/hitkeep
-          test "$(hitkeep --version)" = "$candidate_version"
+          test "$(hitkeep --version)" = "$STABLE_VERSION"
+          brew upgrade --build-from-source PascaleBeier/hitkeep/hitkeep
+          test "$(hitkeep --version)" = "$CANDIDATE_VERSION"
           brew test PascaleBeier/hitkeep/hitkeep
           brew uninstall hitkeep
+          ! command -v hitkeep
 
   cross-cgo:
     if: github.event_name == 'workflow_dispatch' || github.event.pull_request.head.repo.full_name == github.repository

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -32,7 +32,7 @@ jobs:
   build-release:
     needs: release-please
     if: ${{ needs.release-please.outputs.release_created == 'true' }}
-    uses: ./.github/workflows/pipeline.yml
+    uses: $/.github/workflows/pipeline.yml
     permissions:
       contents: write
       packages: write
@@ -294,7 +294,7 @@ jobs:
           go-version-file: go.mod
           cache: false
 
-      - uses: ./.github/actions/setup-node-npm
+      - uses: $/.github/actions/setup-node-npm
 
       - name: Install dashboard dependencies
         working-directory: frontend/dashboard
@@ -475,7 +475,7 @@ jobs:
           persist-credentials: false
           ref: ${{ needs.release-please.outputs.tag_name }}
 
-      - uses: ./.github/actions/setup-node-npm
+      - uses: $/.github/actions/setup-node-npm
 
       - name: Download verified tracker artifact
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches:
       - main
-  workflow_dispatch:
 
 permissions: {}
 
@@ -13,67 +12,7 @@ concurrency:
   cancel-in-progress: false
 
 jobs:
-  recover-release-2-13-18:
-    if: ${{ github.event_name == 'workflow_dispatch' }}
-    runs-on: ubuntu-latest
-    permissions:
-      contents: write
-      id-token: write
-      packages: write
-    steps:
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-        with:
-          persist-credentials: false
-      - uses: ./.github/actions/setup-node-npm
-      - name: Configure npm trusted publishing
-        shell: bash
-        run: |
-          set -euo pipefail
-          id_token="$(curl --fail-with-body --silent --show-error \
-            --header "Authorization: Bearer ${ACTIONS_ID_TOKEN_REQUEST_TOKEN}" \
-            "${ACTIONS_ID_TOKEN_REQUEST_URL}&audience=npm:registry.npmjs.org" | jq -er .value)"
-          npm_token="$(curl --fail-with-body --silent --show-error --request POST \
-            --header "Authorization: Bearer ${id_token}" \
-            'https://registry.npmjs.org/-/npm/v1/oidc/token/exchange/package/@hitkeep%2ftracker' | jq -er .token)"
-          echo "::add-mask::${npm_token}"
-          printf '%s\n' '//registry.npmjs.org/:_authToken=${NODE_AUTH_TOKEN}' > "$RUNNER_TEMP/hitkeep-npmrc"
-          printf 'NODE_AUTH_TOKEN=%s\nNPM_CONFIG_USERCONFIG=%s\n' \
-            "$npm_token" "$RUNNER_TEMP/hitkeep-npmrc" >> "$GITHUB_ENV"
-      - name: Promote tracker latest dist-tag
-        run: npm dist-tag add '@hitkeep/tracker@2.13.18' latest
-      - uses: docker/setup-buildx-action@37fe631027851001ddb9b187196cc803df7f5f0e # v4.3.0
-      - name: Login to GitHub Container Registry
-        uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4.6.0
-        with:
-          registry: ghcr.io
-          username: ${{ github.actor }}
-          password: ${{ github.token }}
-      - name: Login to Docker Hub
-        uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4.6.0
-        with:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
-      - name: Promote verified release image
-        env:
-          DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
-        shell: bash
-        run: |
-          set -euo pipefail
-          source='ghcr.io/pascalebeier/hitkeep@sha256:7068eeef0bb349d35ae6de087bc10f82c36627ff6ba304dadca3de30e049a423'
-          for base in 'ghcr.io/pascalebeier/hitkeep' "${DOCKERHUB_USERNAME}/hitkeep"; do
-            docker buildx imagetools create \
-              --tag "${base}:latest" \
-              --tag "${base}:2" \
-              --tag "${base}:2.13" \
-              "$source"
-          done
-      - name: Publish GitHub release
-        env:
-          GH_TOKEN: ${{ github.token }}
-        run: gh release edit v2.13.18 --draft=false --latest
-
   release-please:
-    if: ${{ github.event_name == 'push' }}
     runs-on: ubuntu-latest
     permissions:
       contents: write
@@ -538,28 +477,13 @@ jobs:
 
       - uses: ./.github/actions/setup-node-npm
 
-      - name: Configure npm trusted publishing
-        shell: bash
-        run: |
-          set -euo pipefail
-          id_token="$(curl --fail-with-body --silent --show-error \
-            --header "Authorization: Bearer ${ACTIONS_ID_TOKEN_REQUEST_TOKEN}" \
-            "${ACTIONS_ID_TOKEN_REQUEST_URL}&audience=npm:registry.npmjs.org" | jq -er .value)"
-          npm_token="$(curl --fail-with-body --silent --show-error --request POST \
-            --header "Authorization: Bearer ${id_token}" \
-            'https://registry.npmjs.org/-/npm/v1/oidc/token/exchange/package/@hitkeep%2ftracker' | jq -er .token)"
-          echo "::add-mask::${npm_token}"
-          printf '%s\n' '//registry.npmjs.org/:_authToken=${NODE_AUTH_TOKEN}' > "$RUNNER_TEMP/hitkeep-npmrc"
-          printf 'NODE_AUTH_TOKEN=%s\nNPM_CONFIG_USERCONFIG=%s\n' \
-            "$npm_token" "$RUNNER_TEMP/hitkeep-npmrc" >> "$GITHUB_ENV"
-
       - name: Download verified tracker artifact
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: tracker-package-${{ needs.release-please.outputs.version }}
           path: tracker-package
 
-      - name: Publish immutable tracker candidate
+      - name: Publish verified tracker
         env:
           VERSION: ${{ needs.release-please.outputs.version }}
         shell: bash
@@ -570,22 +494,23 @@ jobs:
           integrity="sha512-$(openssl dgst -sha512 -binary "$tarball" | base64 | tr -d '\n')"
           existing="$(npm view "@hitkeep/tracker@${VERSION}" dist.integrity 2>/dev/null || true)"
           if [[ -z "$existing" ]]; then
-            npm publish "$tarball" --tag "release-${VERSION}" || true
-            for attempt in {1..6}; do
-              existing="$(npm view "@hitkeep/tracker@${VERSION}" dist.integrity 2>/dev/null || true)"
-              [[ -n "$existing" ]] && break
-              sleep 2
-            done
+            npm publish "$tarball" --tag latest || true
           fi
+          latest=""
+          for attempt in {1..6}; do
+            existing="$(npm view "@hitkeep/tracker@${VERSION}" dist.integrity 2>/dev/null || true)"
+            latest="$(npm view @hitkeep/tracker dist-tags.latest 2>/dev/null || true)"
+            [[ "$existing" == "$integrity" && "$latest" == "$VERSION" ]] && break
+            sleep 2
+          done
           if [[ "$existing" != "$integrity" ]]; then
             echo "published @hitkeep/tracker@${VERSION} does not match the verified artifact" >&2
             exit 1
           fi
-
-      - name: Promote tracker latest dist-tag
-        env:
-          VERSION: ${{ needs.release-please.outputs.version }}
-        run: npm dist-tag add "@hitkeep/tracker@${VERSION}" latest
+          if [[ "$latest" != "$VERSION" ]]; then
+            echo "@hitkeep/tracker latest is $latest; want $VERSION" >&2
+            exit 1
+          fi
 
       - uses: docker/setup-buildx-action@37fe631027851001ddb9b187196cc803df7f5f0e # v4.3.0
 

--- a/.github/workflows/snapshot.yml
+++ b/.github/workflows/snapshot.yml
@@ -14,7 +14,7 @@ concurrency:
 jobs:
   main-snapshot:
     if: "${{ github.event_name == 'push' && !startsWith(github.event.head_commit.message, 'chore(main): release') }}"
-    uses: ./.github/workflows/pipeline.yml
+    uses: $/.github/workflows/pipeline.yml
     permissions:
       contents: write
       packages: write
@@ -48,7 +48,7 @@ jobs:
 
   pr-snapshot:
     if: "${{ github.event_name == 'pull_request' && !github.event.pull_request.draft && github.event.pull_request.head.repo.full_name == github.repository && contains(fromJSON('[\"OWNER\",\"MEMBER\",\"COLLABORATOR\"]'), github.event.pull_request.author_association) }}"
-    uses: ./.github/workflows/pipeline.yml
+    uses: $/.github/workflows/pipeline.yml
     permissions:
       contents: write
       packages: write

--- a/README.md
+++ b/README.md
@@ -43,7 +43,16 @@ HitKeep is web-focused. It favors aggregate traffic and conversion evidence over
 
 ## Quick Start
 
-Download the Docker Compose file and environment template:
+On Apple silicon macOS or x86_64 Linux, install HitKeep with Homebrew:
+
+```bash
+brew install PascaleBeier/hitkeep/hitkeep
+hitkeep --version
+```
+
+Follow the [Homebrew installation guide](https://hitkeep.com/guides/installation/homebrew/) to configure and start HitKeep. On Linux ARM64, use the published ARM64 binary or Docker instead.
+
+For a production-oriented self-hosted setup, download the Docker Compose file and environment template:
 
 ```bash
 mkdir hitkeep && cd hitkeep
@@ -59,7 +68,7 @@ docker compose up -d
 
 Open [http://localhost:8080](http://localhost:8080) and create the first account. Keep `.env` private and retain the same secret across restarts.
 
-Before exposing an instance publicly, follow the [Docker Compose guide](https://hitkeep.com/guides/installation/docker-compose/) for HTTPS and trusted proxies, then review [backups](https://hitkeep.com/guides/data/backups-and-restore/) and the [configuration reference](https://hitkeep.com/reference/configuration/). Prefer a native service? Download the Linux AMD64 or ARM64 binary from [GitHub Releases](https://github.com/PascaleBeier/hitkeep/releases) and follow the [binary installation guide](https://hitkeep.com/guides/installation/binary/).
+Before exposing an instance publicly, follow the [Docker Compose guide](https://hitkeep.com/guides/installation/docker-compose/) for HTTPS and trusted proxies, then review [backups](https://hitkeep.com/guides/data/backups-and-restore/) and the [configuration reference](https://hitkeep.com/reference/configuration/). For a native Linux service, download an AMD64 or ARM64 binary from [GitHub Releases](https://github.com/PascaleBeier/hitkeep/releases) and follow the [binary installation guide](https://hitkeep.com/guides/installation/binary/).
 
 ## Track Your First Site
 

--- a/internal/devtool/docs.go
+++ b/internal/devtool/docs.go
@@ -906,7 +906,7 @@ func validateCIWorkflowContract(root string) error {
 		if bytes.Contains(raw, []byte("actions/setup-node@")) {
 			return fmt.Errorf(".github/workflows/%s bypasses the canonical Node and npm setup action", entry.Name())
 		}
-		if bytes.Contains(raw, []byte("npm ")) && !bytes.Contains(raw, []byte("./.github/actions/setup-node-npm")) {
+		if bytes.Contains(raw, []byte("npm ")) && !bytes.Contains(raw, []byte("$/.github/actions/setup-node-npm")) {
 			return fmt.Errorf(".github/workflows/%s runs npm without the canonical Node and npm setup action", entry.Name())
 		}
 		workflows = append(workflows, raw...)

--- a/internal/devtool/docs.go
+++ b/internal/devtool/docs.go
@@ -198,15 +198,30 @@ func validateReleaseWorkflowGraph(raw []byte) error {
 		if step.Name == "Download verified tracker artifact" {
 			trackerDownload = true
 		}
-		if step.Name == "Publish immutable tracker candidate" &&
-			strings.Contains(step.Run, "npm publish \"$tarball\"") &&
-			strings.Contains(step.Run, "dist.integrity") &&
-			strings.Contains(step.Run, "openssl dgst -sha512") {
-			trackerPublish = true
+		if step.Name != "Publish verified tracker" {
+			continue
 		}
+		for _, fragment := range []string{
+			`npm publish "$tarball" --tag latest || true`,
+			"dist.integrity",
+			"dist-tags.latest",
+			"for attempt in {1..6}",
+			`[[ "$existing" == "$integrity" && "$latest" == "$VERSION" ]]`,
+			`[[ "$existing" != "$integrity" ]]`,
+			`[[ "$latest" != "$VERSION" ]]`,
+			"openssl dgst -sha512",
+		} {
+			if !strings.Contains(step.Run, fragment) {
+				return fmt.Errorf("release workflow tracker publication is missing %q", fragment)
+			}
+		}
+		trackerPublish = true
 	}
-	if !trackerDownload || !trackerPublish {
-		return fmt.Errorf("release workflow finalizer must publish the verified tracker artifact with npm integrity verification")
+	if !trackerDownload {
+		return fmt.Errorf("release workflow finalizer must download the verified tracker artifact")
+	}
+	if !trackerPublish {
+		return fmt.Errorf("release workflow finalizer must publish the verified tracker artifact as latest with npm integrity verification")
 	}
 	draftPublication := false
 	for _, step := range finalizer.Steps {
@@ -231,8 +246,7 @@ func validateReleaseWorkflowGraph(raw []byte) error {
 		positions[step.Name] = index
 	}
 	orderedSteps := []string{
-		"Publish immutable tracker candidate",
-		"Promote tracker latest dist-tag",
+		"Publish verified tracker",
 		"Promote immutable image to mutable tags",
 		"Promote GitHub release",
 	}

--- a/internal/devtool/docs_test.go
+++ b/internal/devtool/docs_test.go
@@ -399,12 +399,17 @@ jobs:
       - docs-attestation
     steps:
       - name: Download verified tracker artifact
-      - name: Publish immutable tracker candidate
+      - name: Publish verified tracker
         run: |
           integrity="$(openssl dgst -sha512 -binary \"$tarball\")"
-          npm publish "$tarball"
+          npm publish "$tarball" --tag latest || true
+          npm view @hitkeep/tracker dist-tags.latest
+          for attempt in {1..6}; do
+            [[ "$existing" == "$integrity" && "$latest" == "$VERSION" ]] && break
+          done
+          [[ "$existing" != "$integrity" ]]
+          [[ "$latest" != "$VERSION" ]]
           npm view @hitkeep/tracker dist.integrity
-      - name: Promote tracker latest dist-tag
       - name: Promote immutable image to mutable tags
       - name: Promote GitHub release
         run: gh release edit "$TAG" --draft=false --latest

--- a/internal/devtool/release_ordering_test.go
+++ b/internal/devtool/release_ordering_test.go
@@ -95,12 +95,17 @@ func TestValidateReleaseWorkflowGraph(t *testing.T) {
       - docs-attestation
     steps:
       - name: Download verified tracker artifact
-      - name: Publish immutable tracker candidate
+      - name: Publish verified tracker
         run: |
           integrity="$(openssl dgst -sha512 -binary \"$tarball\")"
-          npm publish "$tarball"
+          npm publish "$tarball" --tag latest || true
           npm view @hitkeep/tracker dist.integrity
-      - name: Promote tracker latest dist-tag
+          npm view @hitkeep/tracker dist-tags.latest
+          for attempt in {1..6}; do
+            [[ "$existing" == "$integrity" && "$latest" == "$VERSION" ]] && break
+          done
+          [[ "$existing" != "$integrity" ]]
+          [[ "$latest" != "$VERSION" ]]
       - name: Promote immutable image to mutable tags
       - name: Promote GitHub release
         run: gh release edit "$TAG" --draft=false --latest
@@ -196,11 +201,29 @@ func TestValidateReleaseWorkflowGraph(t *testing.T) {
 		t.Fatal("validateReleaseWorkflowGraph() accepted the obsolete array-only npm pack metadata parser")
 	}
 
-	latestBeforeCandidate := strings.Replace(workflow, "      - name: Publish immutable tracker candidate", "      - name: candidate-placeholder", 1)
-	latestBeforeCandidate = strings.Replace(latestBeforeCandidate, "      - name: Promote tracker latest dist-tag", "      - name: Publish immutable tracker candidate", 1)
-	latestBeforeCandidate = strings.Replace(latestBeforeCandidate, "      - name: candidate-placeholder", "      - name: Promote tracker latest dist-tag", 1)
-	if err := validateReleaseWorkflowGraph([]byte(latestBeforeCandidate)); err == nil {
-		t.Fatal("validateReleaseWorkflowGraph() accepted a latest dist-tag promotion before retry-safe candidate publication")
+	withoutLatestTag := strings.Replace(workflow, `npm publish "$tarball" --tag latest || true`, `npm publish "$tarball" || true`, 1)
+	if err := validateReleaseWorkflowGraph([]byte(withoutLatestTag)); err == nil {
+		t.Fatal("validateReleaseWorkflowGraph() accepted tracker publication without the latest dist-tag")
+	}
+
+	withoutPublishRecovery := strings.Replace(workflow, `npm publish "$tarball" --tag latest || true`, `npm publish "$tarball" --tag latest`, 1)
+	if err := validateReleaseWorkflowGraph([]byte(withoutPublishRecovery)); err == nil {
+		t.Fatal("validateReleaseWorkflowGraph() accepted tracker publication without ambiguous-failure recovery")
+	}
+
+	withoutLatestVerification := strings.Replace(workflow, "npm view @hitkeep/tracker dist-tags.latest", "echo skipped latest verification", 1)
+	if err := validateReleaseWorkflowGraph([]byte(withoutLatestVerification)); err == nil {
+		t.Fatal("validateReleaseWorkflowGraph() accepted tracker publication without latest dist-tag verification")
+	}
+
+	withoutIntegrityCheck := strings.Replace(workflow, `[[ "$existing" != "$integrity" ]]`, `[[ -z "$existing" ]]`, 1)
+	if err := validateReleaseWorkflowGraph([]byte(withoutIntegrityCheck)); err == nil {
+		t.Fatal("validateReleaseWorkflowGraph() accepted tracker publication without exact integrity enforcement")
+	}
+
+	withoutLatestCheck := strings.Replace(workflow, `[[ "$latest" != "$VERSION" ]]`, `[[ -z "$latest" ]]`, 1)
+	if err := validateReleaseWorkflowGraph([]byte(withoutLatestCheck)); err == nil {
+		t.Fatal("validateReleaseWorkflowGraph() accepted tracker publication without exact latest-version enforcement")
 	}
 
 	patFinalizer := strings.Replace(workflow, "      - name: Promote GitHub release", "      - name: Promote GitHub release\n        env:\n          GH_TOKEN: ${{ secrets.GHT }}", 1)


### PR DESCRIPTION
## Summary

- validate the Homebrew stable-to-candidate upgrade lifecycle on macOS ARM64
- add Linuxbrew validation on Ubuntu AMD64 and ARM64
- verify candidate version, `brew test`, uninstall, and removal
- allow manual validation with a synthetic next-patch candidate

## Proof

- Release validation run 33522883846: passed on macOS ARM64, Ubuntu AMD64, and Ubuntu ARM64
- Complete local QA run `20260901T151153-5e1a3dd8`: all 11 selected gates passed
- Homebrew tap ARM64 source-build fix: PascaleBeier/homebrew-hitkeep@ee3bdbc
- Localized docs deployed: PascaleBeier/hitkeep-docs@86064e8